### PR TITLE
Change the version comparision syntax, foo|version_compare is deprecated

### DIFF
--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -3,11 +3,11 @@
 
 - name: Install python-firewall
   package: name=python-firewall
-  when: ansible_python_version|version_compare('3', '<')
+  when: ansible_python_version is version('3', '<')
 
 - name: Install python3-firewall
   package: name=python3-firewall
-  when: ansible_python_version|version_compare('3', '>=')
+  when: ansible_python_version is version('3', '>=')
 
 - name: Enable and start firewalld service
   service:


### PR DESCRIPTION
Replace version_compare with version(), version_compare was renamed in 2.5.
ref: https://docs.ansible.com/ansible/2.5/user_guide/playbooks_tests.html#version-comparison