### PR TITLE
Fake pr for debugging https://github.com/linux-system-roles/test-harness/issues/124

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-firewall
+firewall (test pr for debugging https://github.com/linux-system-roles/test-harness/issues/124)
 ========
 
 This role configures the firewall on machines that are using firewalld or


### PR DESCRIPTION
CI tests with collections option fail with "__spec__ is None" if the role has module_utils #124