### PR TITLE
firewall zone support with firewalld

### DIFF
--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -306,7 +306,9 @@ def main():
         _mac_addr, __port, _to_port, _to_addr = args
         _port, _protocol = __port.split("/")
         if _protocol is None:
-            module.fail_json(msg="improper forward_port_by_mac format (missing protocol?)")
+            module.fail_json(
+                msg="improper forward_port_by_mac format (missing protocol?)"
+            )
         if _to_port == "":
             _to_port = None
         if _to_addr == "":

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,12 +1,19 @@
+---
 - name: Install firewalld
-  package: name=firewalld
+  package:
+    name: firewalld
+    state: present
 
 - name: Install python-firewall
-  package: name=python-firewall
+  package:
+    name: python-firewall
+    state: present
   when: ansible_python_version is version('3', '<')
 
 - name: Install python3-firewall
-  package: name=python3-firewall
+  package:
+    name: python3-firewall
+    state: present
   when: ansible_python_version is version('3', '>=')
 
 - name: Enable and start firewalld service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
 
 - name: Configure firewall
   firewall_lib:
+    zone: "{{ item.zone | default(omit) }}"
     service: "{{ item.service | default(omit) }}"
     port: "{{ item.port | default(omit) }}"
     trust: "{{ item.trust | default(omit) }}"
@@ -25,3 +26,4 @@
     state: "{{ item.state }}"
   with_items:
     - "{{ firewall }}"
+  register: firewall_lib_result

--- a/tests/tests_zone.yml
+++ b/tests/tests_zone.yml
@@ -1,0 +1,125 @@
+- name: Ensure that the roles runs with default parameters
+  hosts: all
+  become: true
+
+  tasks:
+  - include_role:
+      name: linux-system-roles.firewall
+
+  - name: Test firewalld zones
+    block:
+
+      # INIT TEST
+
+      - name: Verify used firewalld zones
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall:
+            - { zone: 'internal',
+                state: 'enabled' }
+            - { zone: 'external',
+                state: 'enabled' }
+            - { zone: 'trusted',
+                state: 'enabled' }
+
+      - name: Fail on missing zones
+        fail: msg="Required zones do not exist"
+        when: firewall_lib_result.changed
+
+      # ENSURE STATE
+
+      - name: Setup firewalld
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall_setup_default_solution: no
+          firewall:
+            - { zone: 'internal',
+                service: [ 'tftp', 'ftp' ],
+                port: [ '443/tcp', '443/udp' ],
+                trust: [ 'interface0', 'interface1' ],
+                masq: [ 'interface2', 'interface3' ],
+                forward_port: [ '447/tcp;;1.2.3.4',
+                                '448/tcp;;1.2.3.5' ],
+                state: 'enabled' }
+
+      - name: Fail if no changes are done
+        fail: msg="FAILED"
+        when: not firewall_lib_result.changed
+
+      # ENSURE STATE AGAIN
+
+      - name: Setup firewalld again
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall_setup_default_solution: no
+          firewall:
+            - { zone: 'internal',
+                service: [ 'tftp', 'ftp' ],
+                port: [ '443/tcp', '443/udp' ],
+                trust: [ 'interface0', 'interface1' ],
+                masq: [ 'interface2', 'interface3' ],
+                forward_port: [ '447/tcp;;1.2.3.4',
+                                '448/tcp;;1.2.3.5' ],
+                state: 'enabled' }
+
+      - name: Fail on newly changes
+        fail: msg="FAILED"
+        when: firewall_lib_result.changed
+
+      # VERIFY
+
+      - name: Verify firewalld zone internal services
+        command: firewall-cmd --permanent --zone=internal --list-services
+        register: result
+        failed_when: result.failed
+                     or "tftp" not in result.stdout
+                     or "ftp" not in result.stdout
+
+      - name: Verify firewalld zone internal ports
+        command: firewall-cmd --permanent --zone=internal --list-ports
+        register: result
+        failed_when: result.failed
+                     or "443/tcp" not in result.stdout
+                     or "443/udp" not in result.stdout
+
+      - name: Verify firewalld zone internal forward ports
+        command: firewall-cmd --permanent --zone=internal --list-forward-ports
+        register: result
+        failed_when: result.failed
+                     or "port=447:proto=tcp:toport=:toaddr=1.2.3.4"
+                        not in result.stdout
+                     or "port=448:proto=tcp:toport=:toaddr=1.2.3.5"
+                        not in result.stdout
+
+      - name: Verify firewalld zone external interfaces
+        command: firewall-cmd --permanent --zone=external --list-interfaces
+        register: result
+        failed_when: result.failed
+                     or "interface2" not in result.stdout
+                     or "interface3" not in result.stdout
+
+      - name: Verify firewalld zone trusted interfaces
+        command: firewall-cmd --permanent --zone=trusted --list-interfaces
+        register: result
+        failed_when: result.failed
+                     or "interface0" not in result.stdout
+                     or "interface1" not in result.stdout
+
+    always:
+
+      # CLEANUP: RESET TO ZONE DEFAULTS
+
+      - name: Reset to zone defaults
+        shell:
+          cmd: |
+            firewall-cmd --permanent --load-zone-defaults=internal
+            firewall-cmd --permanent --load-zone-defaults=external
+            firewall-cmd --permanent --load-zone-defaults=trusted
+            firewall-cmd --reload
+
+    when: ansible_distribution == "Fedora" or
+      ((ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+       and ansible_distribution_major_version|int >= 7)


### PR DESCRIPTION
The firewall role has been extended to be able to support the definition
of the zone a change is ensured on. A given zone will be used for these
parameters: `service`, `port` and `forward_port` without a given interface
or MAC address.

Also minor code cleanup has been done to enable the use of zones.