### PR TITLE
Firewalld connection support with firewalld

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,25 @@ port: [ '443/tcp', '443/udp' ]
 
 ### trust
 
-Interface to add or remove from the trusted interfaces.
+Interface to add or remove from the trusted interfaces.The interface will be added to the trusted zone with firewalld.
 
 ```
 trust: 'eth0'
 trust: [ 'eth0', 'eth1' ]
 ```
 
+### trust_by_connection
+
+Current interface of a connection to add or remove from the trusted interfaces. This is a one time lookup. The firewall does not know about NetworkManager connections. The connection needs to exist and an interface needs to be assigned to the connection. The interface will be added to the trusted zone with firewalld.
+
+```
+trust_by_connection: 'MyTrustedConnection'
+trust_by_connection: [ 'MyTrustedConnection1', 'MyTrustedConnection2' ]
+```
+
 ### trust_by_mac
 
-Interface to add or remove to the trusted interfaces by MAC address or MAC address list. Each MAC address will automatically be mapped to the interface that is using this MAC address.
+Interface to add or remove to the trusted interfaces by MAC address or MAC address list. Each MAC address will automatically be mapped to the interface that is using this MAC address. The interface will be added to the trusted zone with firewalld.
 
 ```
 trust_by_mac: "00:11:22:33:44:55"
@@ -108,16 +117,25 @@ trust_by_mac: [ "00:11:22:33:44:55", "00:11:22:33:44:56" ]
 
 ### masq
 
-Interface to add or remove to the interfaces that are masqueraded.
+Interface to add or remove to the interfaces that are masqueraded. The interface will be added to the `external` zone with firewalld.
 
 ```
 masq: 'eth2'
 masq: [ 'eth2', 'eth3' ]
 ```
 
+### masq_by_connection
+
+Current interface of a connection to add or remove from the interfaces that are masqueraded. This is a one time lookup. The firewall does not know about NetworkManager connections. The connection needs to exist and an interface needs to be assigned to the connection. The interface will be added to the `external` zone with firewalld.
+
+```
+masq_by_connection: 'MyExternalConnection'
+masq_by_connection: [ 'MyExternalConnection2', 'MyExternalConnection3' ]
+```
+
 ### masq_by_mac
 
-Interface to add or remove to the interfaces that are masqueraded by MAC address or MAC address list. Each MAC address will automatically be mapped to the interface that is using this MAC address.
+Interface to add or remove to the interfaces that are masqueraded by MAC address or MAC address list. Each MAC address will automatically be mapped to the interface that is using this MAC address. The interface will be added to the `external` zone with firewalld.
 
 ```
 masq_by_mac: "11:22:33:44:55:66"
@@ -132,6 +150,15 @@ Add or remove port forwarding for ports or port ranges over an interface. It nee
 forward_port: 'eth0;447/tcp;;1.2.3.4'
 forward_port: [ 'eth0;447/tcp;;1.2.3.4', 'eth0;448/tcp;;1.2.3.5' ]
 forward_port: '447/tcp;;1.2.3.4'
+```
+
+### forward_port_by_connection
+
+Add or remove port forwarding for ports or port ranges over an interface identified by a connection. It needs to be in the format ```<connection>;<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]```. Each connection will automatically be mapped to the interface that is used by the connection.
+
+```
+forward_port_by_connection: 'connection1;447/tcp;;1.2.3.4'
+forward_port_by_connection: [ 'connection1;447/tcp;;1.2.3.4', 'connection2;448/tcp;;1.2.3.5' ]
 ```
 
 ### forward_port_by_mac
@@ -197,9 +224,8 @@ It is also possible to combine several settings into blocks:
           port: [ '443/tcp', '443/udp' ],
           trust: [ 'eth0', 'eth1' ],
           masq: [ 'eth2', 'eth3' ],
-          state: 'enabled' }
-      - {
-          forward_port: [ 'eth2;447/tcp;;1.2.3.4',
+-         state: 'enabled' }
+-     - { forward_port: [ 'eth2;447/tcp;;1.2.3.4',
                           'eth2;448/tcp;;1.2.3.5' ],
           state: 'enabled' }
       - { zone: "internal", service: 'tftp', state: 'enabled' }
@@ -229,6 +255,23 @@ The block with several services, ports, etc. will be applied at once. If there i
           port: [ '443/tcp', '443/udp' ],
           forward_port: [ '447/tcp;;1.2.3.4',
                           '448/tcp;;1.2.3.5' ],
+          state: 'enabled' }
+  roles:
+    - linux-system-roles.firewall
+
+```
+
+Example for trust, masq and forward_port by connection:
+
+```---
+- name: Configure external zone in firewall
+  hosts: myhost
+
+  vars:
+    firewall:
+      - { trust_by_connection: 'Connection1',
+          masq_by_connection: 'Connection2',
+          forward_port_by_connection: 'Connection3;447/tcp;;1.2.3.4',
           state: 'enabled' }
   roles:
     - linux-system-roles.firewall

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,12 +1,19 @@
+---
 - name: Install firewalld
-  package: name=firewalld
+  package:
+    name: firewalld
+    state: present
 
 - name: Install python-firewall
-  package: name=python-firewall
+  package:
+    name: python-firewall
+    state: present
   when: ansible_python_version is version('3', '<')
 
 - name: Install python3-firewall
-  package: name=python3-firewall
+  package:
+    name: python3-firewall
+    state: present
   when: ansible_python_version is version('3', '>=')
 
 - name: Enable and start firewalld service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
 
 - name: Configure firewall
   firewall_lib:
+    zone: "{{ item.zone | default(omit) }}"
     service: "{{ item.service | default(omit) }}"
     port: "{{ item.port | default(omit) }}"
     trust: "{{ item.trust | default(omit) }}"
@@ -25,3 +26,4 @@
     state: "{{ item.state }}"
   with_items:
     - "{{ firewall }}"
+  register: firewall_lib_result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,11 +18,15 @@
     service: "{{ item.service | default(omit) }}"
     port: "{{ item.port | default(omit) }}"
     trust: "{{ item.trust | default(omit) }}"
+    trust_by_connection: "{{ item.trust_by_connection | default(omit) }}"
     trust_by_mac: "{{ item.trust_by_mac | default(omit) }}"
     masq: "{{ item.masq | default(omit) }}"
+    masq_by_connection: "{{ item.masq_by_connection | default(omit) }}"
     masq_by_mac: "{{ item.masq_by_mac | default(omit) }}"
     forward_port: "{{ item.forward_port | default(omit) }}"
     forward_port_by_mac: "{{ item.forward_port_by_mac | default(omit) }}"
+    forward_port_by_connection:
+      "{{ item.forward_port_by_connection | default(omit) }}"
     state: "{{ item.state }}"
   with_items:
     - "{{ firewall }}"

--- a/tests/tests_connection.yml
+++ b/tests/tests_connection.yml
@@ -1,0 +1,132 @@
+- name: Ensure that the roles runs with default parameters
+  hosts: all
+  become: true
+
+  tasks:
+  - include_role:
+      name: linux-system-roles.firewall
+
+  - name: Test firewalld zones
+    block:
+
+      # GET DEFAULT CONNECTION NAME
+
+      - name: Get default connection name
+        shell: nmcli -t -f NAME c show --active | head -1
+        register: nmcli_result
+
+      - name: Set default_connection fact
+        set_fact:
+          default_connection: "{{ nmcli_result.stdout }}"
+
+      # CREATE DUMMY NETWORK INTERFACES
+
+      - name: Create dummy interfaces using nmcli
+        command: |
+          nmcli con add type dummy ifname dummy0"{{ item }}" \
+          con-name CON-dummy0"{{ item }}" \
+          ipv4.method manual ipv4.addresses 192.0."{{ item }}".1/24
+        with_items:
+          - 0
+          - 1
+          - 2
+          - 3
+
+      # INIT TEST
+
+      - name: Verify used firewalld zones
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall:
+            - { zone: 'external',
+                state: 'enabled' }
+            - { zone: 'trusted',
+                state: 'enabled' }
+
+      - name: Fail on missing zones
+        fail: msg="Required zones do not exist"
+        when: firewall_lib_result.changed
+
+      # ENSURE STATE
+
+      - name: Setup firewalld
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall_setup_default_solution: no
+          firewall:
+            - { trust_by_connection: ['CON-dummy00', 'CON-dummy01'],
+                masq_by_connection: ['CON-dummy02', 'CON-dummy03'],
+                state: 'enabled' }
+            - { forward_port_by_connection: ['CON-dummy02;447/tcp;;1.2.3.4',
+                                             'CON-dummy03;448/udp;;1.2.3.5'],
+                state: 'enabled' }
+
+      - name: Fail if no changes are done
+        fail: msg="FAILED"
+        when: not firewall_lib_result.changed
+
+      # ENSURE STATE AGAIN
+
+      - name: Setup firewalld again
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall_setup_default_solution: no
+          firewall:
+            - { trust_by_connection: ['CON-dummy00', 'CON-dummy01'],
+                masq_by_connection: ['CON-dummy02', 'CON-dummy03'],
+                state: 'enabled' }
+            - { forward_port_by_connection: ['CON-dummy02;447/tcp;;1.2.3.4',
+                                             'CON-dummy03;448/udp;;1.2.3.5'],
+                state: 'enabled' }
+
+      # VERIFY
+
+      - name: Verify firewalld zone external forward ports
+        command: firewall-cmd --permanent --zone=external --list-forward-ports
+        register: result
+        failed_when: result.failed
+                     or "port=447:proto=tcp:toport=:toaddr=1.2.3.4"
+                        not in result.stdout
+                     or "port=448:proto=udp:toport=:toaddr=1.2.3.5"
+                        not in result.stdout
+
+      - name: Verify firewalld zone external interfaces
+        command: firewall-cmd --permanent --zone=external --list-interfaces
+        register: result
+        failed_when: result.failed
+                     or "dummy02" not in result.stdout
+                     or "dummy03" not in result.stdout
+
+      - name: Verify firewalld zone trusted interfaces
+        command: firewall-cmd --permanent --zone=trusted --list-interfaces
+        register: result
+        failed_when: result.failed
+                     or "dummy00" not in result.stdout
+                     or "dummy01" not in result.stdout
+
+    always:
+
+      # CLEANUP: RESET TO ZONE DEFAULTS
+
+      - name: Reset to zone defaults
+        shell:
+          cmd: |
+            firewall-cmd --permanent --load-zone-defaults=external
+            firewall-cmd --permanent --load-zone-defaults=trusted
+            firewall-cmd --reload
+
+      - name: Delete dummy interfaces using nmcli
+        command: nmcli con del CON-dummy0"{{ item }}"
+        with_items:
+          - 0
+          - 1
+          - 2
+          - 3
+
+
+    when: ansible_distribution == "Fedora" or
+      ((ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+       and ansible_distribution_major_version >= "7")

--- a/tests/tests_zone.yml
+++ b/tests/tests_zone.yml
@@ -1,0 +1,125 @@
+- name: Ensure that the roles runs with default parameters
+  hosts: all
+  become: true
+
+  tasks:
+  - include_role:
+      name: linux-system-roles.firewall
+
+  - name: Test firewalld zones
+    block:
+
+      # INIT TEST
+
+      - name: Verify used firewalld zones
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall:
+            - { zone: 'internal',
+                state: 'enabled' }
+            - { zone: 'external',
+                state: 'enabled' }
+            - { zone: 'trusted',
+                state: 'enabled' }
+
+      - name: Fail on missing zones
+        fail: msg="Required zones do not exist"
+        when: firewall_lib_result.changed
+
+      # ENSURE STATE
+
+      - name: Setup firewalld
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall_setup_default_solution: no
+          firewall:
+            - { zone: 'internal',
+                service: [ 'tftp', 'ftp' ],
+                port: [ '443/tcp', '443/udp' ],
+                trust: [ 'interface0', 'interface1' ],
+                masq: [ 'interface2', 'interface3' ],
+                forward_port: [ '447/tcp;;1.2.3.4',
+                                '448/tcp;;1.2.3.5' ],
+                state: 'enabled' }
+
+      - name: Fail if no changes are done
+        fail: msg="FAILED"
+        when: not firewall_lib_result.changed
+
+      # ENSURE STATE AGAIN
+
+      - name: Setup firewalld again
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall_setup_default_solution: no
+          firewall:
+            - { zone: 'internal',
+                service: [ 'tftp', 'ftp' ],
+                port: [ '443/tcp', '443/udp' ],
+                trust: [ 'interface0', 'interface1' ],
+                masq: [ 'interface2', 'interface3' ],
+                forward_port: [ '447/tcp;;1.2.3.4',
+                                '448/tcp;;1.2.3.5' ],
+                state: 'enabled' }
+
+      - name: Fail on newly changes
+        fail: msg="FAILED"
+        when: firewall_lib_result.changed
+
+      # VERIFY
+
+      - name: Verify firewalld zone internal services
+        command: firewall-cmd --permanent --zone=internal --list-services
+        register: result
+        failed_when: result.failed
+                     or "tftp" not in result.stdout
+                     or "ftp" not in result.stdout
+
+      - name: Verify firewalld zone internal ports
+        command: firewall-cmd --permanent --zone=internal --list-ports
+        register: result
+        failed_when: result.failed
+                     or "443/tcp" not in result.stdout
+                     or "443/udp" not in result.stdout
+
+      - name: Verify firewalld zone internal forward ports
+        command: firewall-cmd --permanent --zone=internal --list-forward-ports
+        register: result
+        failed_when: result.failed
+                     or "port=447:proto=tcp:toport=:toaddr=1.2.3.4"
+                        not in result.stdout
+                     or "port=448:proto=tcp:toport=:toaddr=1.2.3.5"
+                        not in result.stdout
+
+      - name: Verify firewalld zone external interfaces
+        command: firewall-cmd --permanent --zone=external --list-interfaces
+        register: result
+        failed_when: result.failed
+                     or "interface2" not in result.stdout
+                     or "interface3" not in result.stdout
+
+      - name: Verify firewalld zone trusted interfaces
+        command: firewall-cmd --permanent --zone=trusted --list-interfaces
+        register: result
+        failed_when: result.failed
+                     or "interface0" not in result.stdout
+                     or "interface1" not in result.stdout
+
+    always:
+
+      # CLEANUP: RESET TO ZONE DEFAULTS
+
+      - name: Reset to zone defaults
+        shell:
+          cmd: |
+            firewall-cmd --permanent --load-zone-defaults=internal
+            firewall-cmd --permanent --load-zone-defaults=external
+            firewall-cmd --permanent --load-zone-defaults=trusted
+            firewall-cmd --reload
+
+    when: ansible_distribution == "Fedora" or
+      ((ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+       and ansible_distribution_major_version|int >= 7)


### PR DESCRIPTION
The firewall role has been extended to be able to support the use of
connections where interfaces are supported at the moment. New variables
have been added for this:

- trust_by_connection
- masq_by_connection
- forward_port_by_connection

Depends on zone support changes (PR#14).
