### PR TITLE
firewall connection support with firewalld

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This role configures the firewall on machines that are using firewalld or
 system-config-firewall/lokkit.
 
 For the configuration the role tries to use the firewalld client interface
-which is available in RHEL-7. If this failes it tries to use the
+which is available in RHEL-7 and later. If this fails it tries to use the
 system-config-firewall interface which is available in RHEL-6 and in RHEL-7
 as an alternative.
 
@@ -34,12 +34,12 @@ After a MAC address change on the system, the firewall needs to be configured
 again if the MAC address has been used in the configuration.
 
 If the MAC address or an interface has been changed in RHEL-6, then it is
-needed to adapt the firewall configuration also. For RHEL-7 this could be done
+needed to adapt the firewall configuration also. For RHEL-7+ this could be done
 automatically if NetworkManager is controlling the affected interface.
 
 ### The Error Case
 
-If the configuration failed or if the firwall configuration limits access to
+If the configuration failed or if the firewall configuration limits access to
 the machine in a bad way, it is most likely be needed to get physical access
 to the machine to fix the issue.
 
@@ -60,7 +60,7 @@ These are the variables that can be passed to the role:
 firewall_setup_default_solution: false
 ```
 
-This turns off the installation and start of the default firewall solution for the specific Fedora or RHEL release. This is intended for users of system-config-firewall on RHEL-7 or Fedora releases.
+This turns off the installation and start of the default firewall solution for the specific Fedora or RHEL release. This is intended for users of system-config-firewall on RHEL-7+ or Fedora releases.
 
 ### zone
 
@@ -90,16 +90,25 @@ port: [ '443/tcp', '443/udp' ]
 
 ### trust
 
-Interface to add or remove from the trusted interfaces.
+Interface to add or remove from the trusted interfaces.  The interface will be added to the trusted zone with firewalld.
 
 ```
 trust: 'eth0'
 trust: [ 'eth0', 'eth1' ]
 ```
 
+### trust_by_connection
+
+Current interface of a connection to add or remove from the trusted interfaces. This is a one time lookup. The firewall does not know about NetworkManager connections. The connection needs to exist and an interface needs to be assigned to the connection. The interface will be added to the trusted zone with firewalld.
+
+```
+trust_by_connection: 'MyTrustedConnection'
+trust_by_connection: [ 'MyTrustedConnection1', 'MyTrustedConnection2' ]
+```
+
 ### trust_by_mac
 
-Interface to add or remove to the trusted interfaces by MAC address or MAC address list. Each MAC address will automatically be mapped to the interface that is using this MAC address.
+Interface to add or remove to the trusted interfaces by MAC address or MAC address list. Each MAC address will automatically be mapped to the interface that is using this MAC address. The interface will be added to the trusted zone with firewalld.
 
 ```
 trust_by_mac: "00:11:22:33:44:55"
@@ -108,16 +117,25 @@ trust_by_mac: [ "00:11:22:33:44:55", "00:11:22:33:44:56" ]
 
 ### masq
 
-Interface to add or remove to the interfaces that are masqueraded.
+Interface to add or remove to the interfaces that are masqueraded. The interface will be added to the `external` zone with firewalld.
 
 ```
 masq: 'eth2'
 masq: [ 'eth2', 'eth3' ]
 ```
 
+### masq_by_connection
+
+Current interface of a connection to add or remove from the interfaces that are masqueraded. This is a one time lookup. The firewall does not know about NetworkManager connections. The connection needs to exist and an interface needs to be assigned to the connection. The interface will be added to the `external` zone with firewalld.
+
+```
+masq_by_connection: 'MyExternalConnection'
+masq_by_connection: [ 'MyExternalConnection2', 'MyExternalConnection3' ]
+```
+
 ### masq_by_mac
 
-Interface to add or remove to the interfaces that are masqueraded by MAC address or MAC address list. Each MAC address will automatically be mapped to the interface that is using this MAC address.
+Interface to add or remove to the interfaces that are masqueraded by MAC address or MAC address list. Each MAC address will automatically be mapped to the interface that is using this MAC address. The interface will be added to the `external` zone with firewalld.
 
 ```
 masq_by_mac: "11:22:33:44:55:66"
@@ -132,6 +150,15 @@ Add or remove port forwarding for ports or port ranges over an interface. It nee
 forward_port: 'eth0;447/tcp;;1.2.3.4'
 forward_port: [ 'eth0;447/tcp;;1.2.3.4', 'eth0;448/tcp;;1.2.3.5' ]
 forward_port: '447/tcp;;1.2.3.4'
+```
+
+### forward_port_by_connection
+
+Add or remove port forwarding for ports or port ranges over an interface identified by a connection. It needs to be in the format ```<connection>;<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]```. Each connection will automatically be mapped to the interface that is used by the connection.
+
+```
+forward_port_by_connection: 'connection1;447/tcp;;1.2.3.4'
+forward_port_by_connection: [ 'connection1;447/tcp;;1.2.3.4', 'connection2;448/tcp;;1.2.3.5' ]
 ```
 
 ### forward_port_by_mac
@@ -197,9 +224,8 @@ It is also possible to combine several settings into blocks:
           port: [ '443/tcp', '443/udp' ],
           trust: [ 'eth0', 'eth1' ],
           masq: [ 'eth2', 'eth3' ],
-          state: 'enabled' }
-      - {
-          forward_port: [ 'eth2;447/tcp;;1.2.3.4',
+-         state: 'enabled' }
+-     - { forward_port: [ 'eth2;447/tcp;;1.2.3.4',
                           'eth2;448/tcp;;1.2.3.5' ],
           state: 'enabled' }
       - { zone: "internal", service: 'tftp', state: 'enabled' }
@@ -229,6 +255,23 @@ The block with several services, ports, etc. will be applied at once. If there i
           port: [ '443/tcp', '443/udp' ],
           forward_port: [ '447/tcp;;1.2.3.4',
                           '448/tcp;;1.2.3.5' ],
+          state: 'enabled' }
+  roles:
+    - linux-system-roles.firewall
+
+```
+
+Example for trust, masq and forward_port by connection:
+
+```---
+- name: Configure external zone in firewall
+  hosts: myhost
+
+  vars:
+    firewall:
+      - { trust_by_connection: 'Connection1',
+          masq_by_connection: 'Connection2',
+          forward_port_by_connection: 'Connection3;447/tcp;;1.2.3.4',
           state: 'enabled' }
   roles:
     - linux-system-roles.firewall

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -49,6 +49,11 @@ options:
       - "Interface to add or remove to the trusted interfaces."
     required: false
     default: null
+  trust_by_connection:
+    description:
+      - "Interface identified by a connection name to add or remove to the trusted interfaces."
+    required: false
+    default: null
   trust_by_mac:
     description:
       - "Interface to add or remove to the trusted interfaces by MAC address."
@@ -57,6 +62,11 @@ options:
   masq:
     description:
       - "Interface to add or remove to the interfaces that are masqueraded."
+    required: false
+    default: null
+  masq_by_connection:
+    description:
+      - "Interface identified by a connection name to add or remove to the interfaces that are masqueraded."
     required: false
     default: null
   masq_by_mac:
@@ -72,6 +82,14 @@ options:
         Add or remove port forwarding for ports or port ranges over for interface or zone. Omit the interface part before ';' for use within a zone.
         It needs to be in the format
         [<interface>;]<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>].
+    required: false
+    default: null
+  forward_port_by_connection:
+    description:
+      - >-
+        Add or remove port forwarding for ports or port ranges over an interface
+        identified ba a connection name. It needs to be in the format
+        <connection>;<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>].
     required: false
     default: null
   forward_port_by_mac:
@@ -227,16 +245,68 @@ def get_device_for_mac(mac_addr):
     return None
 
 
+def get_interface_for_connection(name):
+    """Get interface for the connection name from NM"""
+
+    if HAS_FIREWALLD_NM and nm_is_imported:
+        client = NM.Client.new(None)
+        for nm_con in client.get_connections():
+            if nm_con.get_id() == name:
+                return nm_con.get_interface_name()
+
+    return None
+
+
+def parse_forward_port(module, item, item_type=None):
+    if item_type == "connection":
+        type_string = "forward_port_by_connection"
+    elif item_type == "mac":
+        type_string = "forward_port_by_mac"
+    else:
+        type_string = "forward_port"
+
+    args = item.split(";")
+    if len(args) == 4:
+        _interface, __port, _to_port, _to_addr = args
+    elif len(args) == 3 and item_type is None:
+        _interface = ""
+        __port, _to_port, _to_addr = args
+    else:
+        module.fail_json(msg="improper %s format: %s" % (type_string, item))
+
+    _port, _protocol = __port.split("/")
+    if _protocol is None:
+        module.fail_json(msg="improper %s format (missing protocol?)" % type_string)
+    if _to_port == "":
+        _to_port = None
+    if _to_addr == "":
+        _to_addr = None
+
+    if item_type == "connection":
+        _interface = get_interface_for_connection(_interface)
+        if _interface is None:
+            module.fail_json(msg="Connection '%s' not resolvable" % _interface)
+    elif item_type == "mac":
+        _interface = get_device_for_mac(_interface)
+        if _interface is None:
+            module.fail_json(msg="MAC address not found %s" % _interface)
+
+    return (_interface, _port, _protocol, _to_port, _to_addr)
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
             service=dict(required=False, type="list", default=[]),
             port=dict(required=False, type="list", default=[]),
             trust=dict(required=False, type="list", default=[]),
+            trust_by_connection=dict(required=False, type="list", default=[]),
             trust_by_mac=dict(required=False, type="list", default=[]),
             masq=dict(required=False, type="list", default=[]),
+            masq_by_connection=dict(required=False, type="list", default=[]),
             masq_by_mac=dict(required=False, type="list", default=[]),
             forward_port=dict(required=False, type="list", default=[]),
+            forward_port_by_connection=dict(required=False, type="list", default=[]),
             forward_port_by_mac=dict(required=False, type="list", default=[]),
             zone=dict(required=False, type="str", default=None),
             state=dict(choices=["enabled", "disabled"], required=True),
@@ -246,10 +316,14 @@ def main():
                 "service",
                 "port",
                 "trust",
+                "trust_by_connection",
                 "trust_by_mac",
                 "masq",
+                "masq_by_connection",
                 "masq_by_mac",
-                "forward_prot",
+                "forward_port",
+                "forward_port_by_connection",
+                "forward_port_by_mac",
             ],
         ),
         supports_check_mode=True,
@@ -281,45 +355,40 @@ def main():
         masq_by_mac.append(_interface)
     forward_port = []
     for item in module.params["forward_port"]:
-        args = item.split(";")
-        if len(args) == 4:
-            _interface, __port, _to_port, _to_addr = args
-        elif len(args) == 3:
-            _interface = ""
-            __port, _to_port, _to_addr = args
-        else:
-            module.fail_json(msg="improper forward_port format: %s" % item)
-        _port, _protocol = __port.split("/")
-        if _protocol is None:
-            module.fail_json(msg="improper forward port format (missing protocol?)")
-        if _to_port == "":
-            _to_port = None
-        if _to_addr == "":
-            _to_addr = None
-        forward_port.append((_interface, _port, _protocol, _to_port, _to_addr))
-
+        forward_port.append(parse_forward_port(module, item))
     forward_port_by_mac = []
     for item in module.params["forward_port_by_mac"]:
-        args = item.split(";")
-        if len(args) != 4:
-            module.fail_json(msg="improper forward_port_by_mac format")
-        _mac_addr, __port, _to_port, _to_addr = args
-        _port, _protocol = __port.split("/")
-        if _protocol is None:
-            module.fail_json(
-                msg="improper forward_port_by_mac format (missing protocol?)"
-            )
-        if _to_port == "":
-            _to_port = None
-        if _to_addr == "":
-            _to_addr = None
-        _interface = get_device_for_mac(_mac_addr)
-        if _interface is None:
-            module.fail_json(msg="MAC address not found %s" % _mac_addr)
-        forward_port_by_mac.append((_interface, _port, _protocol, _to_port, _to_addr))
+        forward_port_by_mac.append(parse_forward_port(module, item, "mac"))
+
     zone = module.params["zone"]
     if HAS_SYSTEM_CONFIG_FIREWALL and zone is not None:
         module.fail_json(msg="Zone can not be used with system-config-firewall/lokkit.")
+    trust_by_connection = []
+    for item in module.params["trust_by_connection"]:
+        _interface = get_interface_for_connection(item)
+        if _interface is None:
+            module.fail_json(msg="Connection '%s' not resolvable" % item)
+        trust_by_connection.append(_interface)
+    masq_by_connection = []
+    for item in module.params["masq_by_connection"]:
+        _interface = get_interface_for_connection(item)
+        if _interface is None:
+            module.fail_json(msg="Connection '%s' not resolvable" % item)
+        masq_by_connection.append(_interface)
+    forward_port_by_connection = []
+    for item in module.params["forward_port_by_connection"]:
+        forward_port_by_connection.append(
+            parse_forward_port(module, item, "connection")
+        )
+    if not (HAS_FIREWALLD_NM or nm_is_imported()) and (
+        len(trust_by_connection) > 0
+        or len(masq_by_connection) > 0
+        or len(forward_port_by_connection) > 0
+    ):
+        module.fail_json(
+            msg="The use of connections requires firewalld and NetworkManager."
+        )
+
     desired_state = module.params["state"]
 
     if HAS_FIREWALLD:
@@ -335,13 +404,14 @@ def main():
 
         trusted_zone = "trusted"
         external_zone = "external"
+        default_zone = fw.getDefaultZone()
         if zone is not None:
             if zone not in fw.getZones():
                 module.fail_json(msg="Runtime zone '%s' does not exist." % zone)
             if zone not in fw.config().getZoneNames():
                 module.fail_json(msg="Permanent zone '%s' does not exist." % zone)
         else:
-            zone = fw.getDefaultZone()
+            zone = default_zone
         fw_zone = fw.config().getZoneByName(zone)
         fw_settings = fw_zone.getSettings()
 
@@ -357,14 +427,14 @@ def main():
                 if not fw_settings.queryService(item):
                     fw_settings.addService(item)
                     changed = True
-                    changed_zones[fw_zone] = fw_settings
+                    changed_zones[zone] = fw_settings
             elif desired_state == "disabled":
                 if fw.queryService(zone, item):
                     fw.removeService(zone, item)
                 if fw_settings.queryService(item):
                     fw_settings.removeService(item)
                     changed = True
-                    changed_zones[fw_zone] = fw_settings
+                    changed_zones[zone] = fw_settings
 
         # port
         for _port, _protocol in port:
@@ -375,7 +445,7 @@ def main():
                 if not fw_settings.queryPort(_port, _protocol):
                     fw_settings.addPort(_port, _protocol)
                     changed = True
-                    changed_zones[fw_zone] = fw_settings
+                    changed_zones[zone] = fw_settings
             elif desired_state == "disabled":
                 if fw.queryPort(zone, _port, _protocol):
                     fw.removePort(zone, _port, _protocol)
@@ -383,93 +453,107 @@ def main():
                 if fw_settings.queryPort(_port, _protocol):
                     fw_settings.removePort(_port, _protocol)
                     changed = True
-                    changed_zones[fw_zone] = fw_settings
+                    changed_zones[zone] = fw_settings
 
         # trust, trust_by_mac
-        if len(trust) > 0 or len(trust_by_mac) > 0:
+        if len(trust) > 0 or len(trust_by_connection) > 0 or len(trust_by_mac) > 0:
             items = trust
+            if len(trust_by_connection) > 0:
+                items.extend(trust_by_connection)
             if len(trust_by_mac) > 0:
                 items.extend(trust_by_mac)
 
             if zone != trusted_zone:
-                _fw_zone = fw.config().getZoneByName(trusted_zone)
-                if _fw_zone in changed_zones:
-                    _fw_settings = changed_zones[_fw_zone]
+                _zone = trusted_zone
+                _fw_zone = fw.config().getZoneByName(_zone)
+                if _zone in changed_zones:
+                    _fw_settings = changed_zones[_zone]
                 else:
                     _fw_settings = _fw_zone.getSettings()
             else:
+                _zone = zone
                 _fw_zone = fw_zone
                 _fw_settings = fw_settings
 
             for item in items:
                 if desired_state == "enabled":
-                    if try_set_zone_of_interface(trusted_zone, item):
+                    if try_set_zone_of_interface(_zone, item):
                         changed = True
                     else:
-                        if not fw.queryInterface(trusted_zone, item):
-                            fw.changeZoneOfInterface(trusted_zone, item)
+                        if not fw.queryInterface(_zone, item):
+                            fw.changeZoneOfInterface(_zone, item)
                             changed = True
                         if not _fw_settings.queryInterface(item):
                             _fw_settings.addInterface(item)
                             changed = True
-                            changed_zones[_fw_zone] = _fw_settings
+                            changed_zones[_zone] = _fw_settings
                 elif desired_state == "disabled":
                     if try_set_zone_of_interface("", item):
                         if module.check_mode:
                             module.exit_json(changed=True)
                     else:
-                        if fw.queryInterface(trusted_zone, item):
-                            fw.removeInterface(trusted_zone, item)
+                        if fw.queryInterface(_zone, item):
+                            fw.removeInterface(_zone, item)
                             changed = True
                         if _fw_settings.queryInterface(item):
                             _fw_settings.removeInterface(item)
                             changed = True
-                            changed_zones[_fw_zone] = _fw_settings
+                            changed_zones[_zone] = _fw_settings
 
         # masq, masq_by_mac
-        if len(masq) > 0 or len(masq_by_mac) > 0:
+        if len(masq) > 0 or len(masq_by_connection) > 0 or len(masq_by_mac) > 0:
             items = masq
+            if len(masq_by_connection) > 0:
+                items.extend(masq_by_connection)
             if len(masq_by_mac) > 0:
                 items.extend(masq_by_mac)
 
             if zone != external_zone:
-                _fw_zone = fw.config().getZoneByName(external_zone)
-                if _fw_zone in changed_zones:
-                    _fw_settings = changed_zones[_fw_zone]
+                _zone = external_zone
+                _fw_zone = fw.config().getZoneByName(_zone)
+                if _zone in changed_zones:
+                    _fw_settings = changed_zones[_zone]
                 else:
                     _fw_settings = _fw_zone.getSettings()
             else:
+                _zone = zone
                 _fw_zone = fw_zone
                 _fw_settings = fw_settings
 
             for item in items:
                 if desired_state == "enabled":
-                    if try_set_zone_of_interface(external_zone, item):
+                    if try_set_zone_of_interface(_zone, item):
                         changed = True
                     else:
-                        if not fw.queryInterface(external_zone, item):
-                            fw.changeZoneOfInterface(external_zone, item)
+                        if not fw.queryInterface(_zone, item):
+                            fw.changeZoneOfInterface(_zone, item)
                             changed = True
                         if not _fw_settings.queryInterface(item):
                             _fw_settings.addInterface(item)
                             changed = True
-                            changed_zones[_fw_zone] = _fw_settings
+                            changed_zones[_zone] = _fw_settings
                 elif desired_state == "disabled":
                     if try_set_zone_of_interface("", item):
                         if module.check_mode:
                             module.exit_json(changed=True)
                     else:
-                        if fw.queryInterface(external_zone, item):
-                            fw.removeInterface(external_zone, item)
+                        if fw.queryInterface(_zone, item):
+                            fw.removeInterface(_zone, item)
                             changed = True
                         if _fw_settings.queryInterface(item):
                             _fw_settings.removeInterface(item)
                             changed = True
-                            changed_zones[_fw_zone] = _fw_settings
+                            changed_zones[_zone] = _fw_settings
 
         # forward_port, forward_port_by_mac
-        if len(forward_port) > 0 or len(forward_port_by_mac) > 0:
+        if (
+            len(forward_port) > 0
+            or len(forward_port_by_connection) > 0
+            or len(forward_port_by_mac) > 0
+        ):
             items = forward_port
+            if len(forward_port_by_connection) > 0:
+                items.extend(forward_port_by_connection)
             if len(forward_port_by_mac) > 0:
                 items.extend(forward_port_by_mac)
 
@@ -480,8 +564,8 @@ def main():
                     _zone = zone
                 if _zone != "" and _zone != zone:
                     _fw_zone = fw.config().getZoneByName(_zone)
-                    if _fw_zone in changed_zones:
-                        _fw_settings = changed_zones[_fw_zone]
+                    if _zone in changed_zones:
+                        _fw_settings = changed_zones[_zone]
                     else:
                         _fw_settings = _fw_zone.getSettings()
                 else:
@@ -501,7 +585,7 @@ def main():
                             _port, _protocol, _to_port, _to_addr
                         )
                         changed = True
-                        changed_zones[_fw_zone] = _fw_settings
+                        changed_zones[_zone] = _fw_settings
                 elif desired_state == "disabled":
                     if fw.queryForwardPort(_zone, _port, _protocol, _to_port, _to_addr):
                         fw.removeForwardPort(
@@ -515,12 +599,13 @@ def main():
                             _port, _protocol, _to_port, _to_addr
                         )
                         changed = True
-                        changed_zones[_fw_zone] = _fw_settings
+                        changed_zones[_zone] = _fw_settings
 
         # apply changes
         if changed:
             for _zone in changed_zones:
-                _zone.update(changed_zones[_zone])
+                _fw_zone = fw.config().getZoneByName(_zone)
+                _fw_zone.update(changed_zones[_zone])
             module.exit_json(changed=True)
 
     elif HAS_SYSTEM_CONFIG_FIREWALL:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,11 +18,15 @@
     service: "{{ item.service | default(omit) }}"
     port: "{{ item.port | default(omit) }}"
     trust: "{{ item.trust | default(omit) }}"
+    trust_by_connection: "{{ item.trust_by_connection | default(omit) }}"
     trust_by_mac: "{{ item.trust_by_mac | default(omit) }}"
     masq: "{{ item.masq | default(omit) }}"
+    masq_by_connection: "{{ item.masq_by_connection | default(omit) }}"
     masq_by_mac: "{{ item.masq_by_mac | default(omit) }}"
     forward_port: "{{ item.forward_port | default(omit) }}"
     forward_port_by_mac: "{{ item.forward_port_by_mac | default(omit) }}"
+    forward_port_by_connection:
+      "{{ item.forward_port_by_connection | default(omit) }}"
     state: "{{ item.state }}"
   with_items:
     - "{{ firewall }}"

--- a/tests/tests_connection.yml
+++ b/tests/tests_connection.yml
@@ -1,0 +1,151 @@
+- name: Ensure that the roles runs with default parameters
+  hosts: all
+  become: true
+
+  tasks:
+  - include_role:
+      name: linux-system-roles.firewall
+
+  - name: Test firewalld zones
+    block:
+
+      # GET DEFAULT CONNECTION NAME
+
+      - name: ensure nmcli is present
+        package:
+          name: NetworkManager
+          state: present
+
+      - name: Ensure NetworkManager is running
+        service:
+          name: NetworkManager
+          state: started
+
+      - name: Get default connection name
+        shell: nmcli -t -f NAME c show --active | head -1
+        register: nmcli_result
+
+      - name: Set default_connection fact
+        set_fact:
+          default_connection: "{{ nmcli_result.stdout }}"
+
+      # CREATE DUMMY NETWORK INTERFACES
+
+      - name: Create dummy interfaces using nmcli
+        command: |
+          nmcli con add type dummy ifname dummy0"{{ item }}" \
+          con-name CON-dummy0"{{ item }}" \
+          ipv4.method manual ipv4.addresses 192.0."{{ item }}".1/24
+        with_items:
+          - 0
+          - 1
+          - 2
+          - 3
+
+      # INIT TEST
+
+      - name: Verify used firewalld zones
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall:
+            - { zone: 'external',
+                state: 'enabled' }
+            - { zone: 'trusted',
+                state: 'enabled' }
+
+      - name: Fail on missing zones
+        fail: msg="Required zones do not exist"
+        when: firewall_lib_result.changed
+
+      # ENSURE STATE
+
+      - name: Setup firewalld
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall_setup_default_solution: no
+          firewall:
+            - { trust_by_connection: ['CON-dummy00', 'CON-dummy01'],
+                masq_by_connection: ['CON-dummy02', 'CON-dummy03'],
+                state: 'enabled' }
+            - { forward_port_by_connection: ['CON-dummy02;447/tcp;;1.2.3.4',
+                                             'CON-dummy03;448/udp;;1.2.3.5'],
+                state: 'enabled' }
+
+      - name: Fail if no changes are done
+        fail: msg="FAILED"
+        when: not firewall_lib_result.changed
+
+      # ENSURE STATE AGAIN
+
+      - name: Setup firewalld again
+        include_role:
+          name: linux-system-roles.firewall
+        vars:
+          firewall_setup_default_solution: no
+          firewall:
+            - { trust_by_connection: ['CON-dummy00', 'CON-dummy01'],
+                masq_by_connection: ['CON-dummy02', 'CON-dummy03'],
+                state: 'enabled' }
+            - { forward_port_by_connection: ['CON-dummy02;447/tcp;;1.2.3.4',
+                                             'CON-dummy03;448/udp;;1.2.3.5'],
+                state: 'enabled' }
+
+      # VERIFY
+
+      - name: Verify firewalld zone external forward ports
+        command: firewall-cmd --permanent --zone=external --list-forward-ports
+        register: result
+        failed_when: result.failed
+                     or "port=447:proto=tcp:toport=:toaddr=1.2.3.4"
+                        not in result.stdout
+                     or "port=448:proto=udp:toport=:toaddr=1.2.3.5"
+                        not in result.stdout
+
+      - name: Verify firewalld zone external interfaces
+        command: firewall-cmd --permanent --zone=external --list-interfaces
+        register: result
+        failed_when: result.failed
+                     or "dummy02" not in result.stdout
+                     or "dummy03" not in result.stdout
+
+      - name: Verify firewalld zone trusted interfaces
+        command: firewall-cmd --permanent --zone=trusted --list-interfaces
+        register: result
+        failed_when: result.failed
+                     or "dummy00" not in result.stdout
+                     or "dummy01" not in result.stdout
+
+    always:
+
+      # CLEANUP: RESET TO ZONE DEFAULTS
+
+      - name: Reset to zone defaults
+        shell:
+          cmd: |
+            firewall-cmd --permanent --load-zone-defaults=external
+            firewall-cmd --permanent --load-zone-defaults=trusted
+            firewall-cmd --reload
+
+      - name: Delete dummy interfaces using nmcli
+        command: nmcli con del CON-dummy0"{{ item }}"
+        with_items:
+          - 0
+          - 1
+          - 2
+          - 3
+
+      - name: Ensure NetworkManager is stopped
+        service:
+          name: NetworkManager
+          state: stopped
+
+      - name: ensure nmcli is absent
+        package:
+          name: NetworkManager
+          state: absent
+
+    when: ansible_distribution == "Fedora" or
+      ((ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+       and ansible_distribution_major_version >= "7")


### PR DESCRIPTION
The firewall role has been extended to be able to support the use of
connections where interfaces are supported at the moment. New variables
have been added for this:

- trust_by_connection
- masq_by_connection
- forward_port_by_connection

Depends on zone support changes (PR#14).
replaces https://github.com/linux-system-roles/firewall/pull/16