### PR TITLE
Drop support for Ansible 2.8 by bumping the Ansible version to 2.9

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,7 +5,7 @@ on:  # yamllint disable-line rule:truthy
 env:
   TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.4.0"
   LSR_ANSIBLE_TEST_DOCKER: "true"
-  LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
+  LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: libdbus-1-dev
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ansible_pytest_extra_requirements.txt
+++ b/ansible_pytest_extra_requirements.txt
@@ -2,6 +2,5 @@
 
 # ansible and dependencies for all supported platforms
 ansible ; python_version > "2.6"
-ansible<2.7 ; python_version < "2.7"
 idna<2.8 ; python_version < "2.7"
 PyYAML<5.1 ; python_version < "2.7"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Configure firewalld and system-config-firewall/lokkit
   company: Red Hat, Inc.
   license: GPLv2+
-  min_ansible_version: 2.7
+  min_ansible_version: 2.9
   galaxy_tags: [ 'firewall', 'system' ]
   platforms:
     - name: Fedora


### PR DESCRIPTION
Bug 1989197 - drop support for Ansible 2.8
https://bugzilla.redhat.com/show_bug.cgi?id=1989197