### PR TITLE
fix module docs; set target to default for absent, disabled; fix unit tests

### DIFF
--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -157,10 +157,11 @@ options:
     default: no
   state:
     description:
-      Ensure presence or absence of entries.
+      Ensure presence or absence of entries.  Use C(present) and C(absent) only
+      for zone-only operations, or for target operations.
     required: true
     type: str
-    choices: ["enabled", "disabled","present","absent"]
+    choices: ["enabled", "disabled", "present", "absent"]
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -741,8 +742,7 @@ def main():
                     fw_settings.setTarget(target)
                 changed = True
         elif state in ["absent", "disabled"]:
-            if state == "absent":
-                target = "default"
+            target = "default"
             if permanent and fw_settings.getTarget() != target:
                 if not module.check_mode:
                     fw_settings.setTarget(target)

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -227,8 +227,8 @@ TEST_DATA = {
         },
         "disabled": {
             "expected": {
-                "permanent": [call("ACCEPT")],
-                "query_mock": {"getTarget.return_value": "default"},
+                "permanent": [call("default")],
+                "query_mock": {"getTarget.return_value": "DROP"},
                 "called_mock_name": "setTarget",
             }
         },
@@ -308,6 +308,7 @@ class FirewallLibParsers(unittest.TestCase):
 class FirewallLibMain(unittest.TestCase):
     """Test main function."""
 
+    @patch("firewall_lib.HAS_FIREWALLD", False)
     def test_main_error_no_firewall_backend(self, am_class):
         with self.assertRaises(MockException):
             firewall_lib.main()


### PR DESCRIPTION
Fix module docs - minor updates
When setting `target` with `state: absent` or `state: disabled`, set value to `default`
Fix some failing unit tests