### PR TITLE
support for user-created zones; pass a.p.firewalld tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ These are the variables that can be passed to the role:
 
 ### zone
 
-Name of the zone that should be modified. If it is not set, the default zone will be used. It will have an effect on these parameters: `service`, `port` and `forward_port`.
+Name of the zone that should be modified. If it is not set, the default zone
+will be used. It will have an effect on these variables: `service`, `port`,
+`source_port`, `forward_port`, `masquerade`, `rich_rule`, `source`, `interface`,
+`icmp_block`, `icmp_block_inversion`, and `target`.
+
+You can also use this to add/remove user-created zones.  Specify the `zone`
+variable with no other variables, and use `state: present` to add the zone, or
+`state: absent` to remove it.
 
 ```
 zone: 'public'
@@ -42,7 +49,8 @@ zone: 'public'
 
 ### service
 
-Name of a service or service list to add or remove inbound access to. The service needs to be defined in firewalld.
+Name of a service or service list to add or remove inbound access to. The
+service needs to be defined in firewalld.
 
 ```
 service: 'ftp'
@@ -51,20 +59,131 @@ service: [ 'ftp', 'tftp' ]
 
 ### port
 
-Port or port range or a list of them to add or remove inbound access to. It needs to be in the format ```<port>[-<port>]/<protocol>```.
+Port or port range or a list of them to add or remove inbound access to. It
+needs to be in the format ```<port>[-<port>]/<protocol>```.
 
 ```
 port: '443/tcp'
 port: [ '443/tcp', '443/udp' ]
 ```
 
+### source_port
+
+Port or port range or a list of them to add or remove source port access to. It
+needs to be in the format ```<port>[-<port>]/<protocol>```.
+
+```
+source_port: '443/tcp'
+source_port: [ '443/tcp', '443/udp' ]
+```
+
 ### forward_port
 
-Add or remove port forwarding for ports or port ranges for a zone. It needs to be in the format ```<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]```.
+Add or remove port forwarding for ports or port ranges for a zone. It takes two
+different formats:
+* string or a list of strings in the format like `firewall-cmd
+  --add-forward-port` e.g. `<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]`
+* dict or list of dicts in the format like `ansible.posix.firewalld`:
 
+```
+forward_port:
+  port: <port>
+  proto: <protocol>
+  [toport: <to-port>]
+  [toaddr: <to-addr>]
+```
+examples
 ```
 forward_port: '447/tcp;;1.2.3.4'
 forward_port: [ '447/tcp;;1.2.3.4', '448/tcp;;1.2.3.5' ]
+forward_port:
+  - port: 447
+    proto: tcp
+    toaddr: 1.2.3.4
+  - port: 448
+    proto: tcp
+    toaddr: 1.2.3.5
+```
+`port_forward` is an alias for `forward_port`.  Its use is deprecated and will
+be removed in an upcoming release.
+
+### masquerade
+
+Enable or disable masquerade on the given zone.
+
+```
+masquerade: false
+```
+
+### rich_rule
+
+String or list of rich rule strings. For the format see (Syntax for firewalld
+rich language
+rules)[https://firewalld.org/documentation/man-pages/firewalld.richlanguage.html]
+
+```
+rich_rule: rule service name="ftp" audit limit value="1/m" accept
+```
+
+### source
+
+List of source address or address range strings.  A source address or address
+range is either an IP address or a network IP address with a mask for IPv4 or
+IPv6. For IPv4, the mask can be a network mask or a plain number. For IPv6 the
+mask is a plain number.
+
+```
+source: 192.0.2.0/24
+```
+
+### interface
+
+String or list of interface name strings.
+
+```
+interface: eth2
+```
+
+### icmp_block
+
+String or list of ICMP type strings to block.  The ICMP type names needs to be
+defined in firewalld configuration.
+
+```
+icmp_block: echo-request
+```
+
+### icmp_block_inversion
+
+ICMP block inversion bool setting.  It enables or disables inversion of ICMP
+blocks for a zone in firewalld.
+
+```
+icmp_block_inversion: true
+```
+
+### target
+
+The firewalld zone target.  If the state is set to `absent`,this will reset the
+target to default.  Valid values are "default", "ACCEPT", "DROP", "%%REJECT%%".
+
+```
+target: ACCEPT
+```
+
+### timeout
+
+The amount of time in seconds a setting is in effect. The timeout is usable if
+
+* state is set to `enabled`
+* firewalld is running and `runtime` is set
+* setting is used with services, ports, source ports, forward ports, masquerade,
+  rich rules or icmp blocks
+
+```
+timeout: 60
+state: enabled
+service: https
 ```
 
 ### state
@@ -72,8 +191,20 @@ forward_port: [ '447/tcp;;1.2.3.4', '448/tcp;;1.2.3.5' ]
 Enable or disable the entry.
 
 ```
-state: 'enabled' | 'disabled'
+state: 'enabled' | 'disabled' | 'present' | 'absent'
 ```
+NOTE: `present` and `absent` are only used for `zone` and `target` operations,
+and cannot be used for any other operation.
+
+NOTE: `zone` - use `state: present` to add a zone, and `state: absent` to remove
+a zone, when zone is the only variable e.g.
+```
+firewall:
+  zone: my-new-zone
+  state: present
+```
+NOTE: `target` - you can also use `state: present` to add a target - `state:
+absent` will reset the target to the default.
 
 Example Playbooks
 -----------------

--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -326,6 +326,18 @@
         register: result
         failed_when: result.failed or result.changed
 
+      - name: Firewalld custom zone
+        firewall_lib:
+          zone: customzone
+          state: present
+          permanent: yes
+        register: result
+
+      - name: assert firewalld custom zone
+        assert:
+          that:
+            - result is changed
+
     always:
 
       # CLEANUP: RESET TO ZONE DEFAULTS


### PR DESCRIPTION
Adds support for user-created zones - user can add/remove zones.
Makes the role pass a.p.firewalld integration tests.
Code cleanup

Co-authored-by: Rich Megginson <rmeggins@redhat.com>