### PR TITLE
update tox-lsr version to 2.7.1

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.7.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.7.1"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default


### PR DESCRIPTION
update the tox-lsr version used in github actions tox CI
to 2.7.1

The only difference between this an 2.7.0 is that Ansible 2.12
is now GA.