### PR TITLE
ensure that changes to target take effect immediately

### DIFF
--- a/tests/tests_target.yml
+++ b/tests/tests_target.yml
@@ -1,0 +1,44 @@
+- hosts: all
+  tasks:
+    - name: Call role to change target settings
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall:
+          - set_default_zone: public
+            state: enabled
+            permanent: yes
+          - target: DROP
+            state: enabled
+            permanent: yes
+
+    - name: Get target setting
+      command: firewall-cmd --info-zone=public
+      changed_when: false
+      register: __result
+
+    - name: Verify target setting
+      assert:
+        that: __expected in __result.stdout_lines
+      vars:
+        __expected: "  target: DROP"
+
+    - name: Call role to reset target settings
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall:
+          target: DROP
+          state: absent
+          permanent: yes
+
+    - name: Get target setting
+      command: firewall-cmd --info-zone=public
+      changed_when: false
+      register: __result
+
+    - name: Verify target setting was reset
+      assert:
+        that: __expected not in __result.stdout_lines
+      vars:
+        __expected: "  target: DROP"

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -390,7 +390,7 @@ class FirewallLibMain(unittest.TestCase):
         with self.assertRaises(MockException):
             firewall_lib.main()
         am.fail_json.assert_called_with(
-            msg="timeout can not be used with icmp_block_inverson only"
+            msg="timeout can not be used with icmp_block_inversion only"
         )
 
     @patch("firewall_lib.HAS_FIREWALLD", True)


### PR DESCRIPTION
When changing the target, a reload is required in order for the
changes to take effect, so ensure that this happens.

The code has been refactored slightly in order to use the same
reload logic for other cases where reload is required.

A new test was added for the target use cases.
