### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 firewall: []
 firewall_setup_default_solution: true
+
+# ansible_facts required by the role
+__firewall_required_facts:
+  - python_version

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__firewall_required_facts) == __firewall_required_facts
+
 - name: Install firewalld
   package:
     name: firewalld
@@ -15,9 +21,3 @@
     name: python3-firewall
     state: present
   when: ansible_python_version is version('3', '>=')
-
-- name: Enable and start firewalld service
-  service:
-    name: firewalld
-    state: started
-    enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
-- include: firewalld.yml
+- include_tasks: firewalld.yml
+
+- name: Enable and start firewalld service
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
 
 - name: Configure firewall
   firewall_lib:

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,7 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.firewall
+        tasks_from: firewalld.yml
+        public: true

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,5 @@
 - name: Ensure that the roles runs with default parameters
   hosts: all
-
+  gather_facts: false
   roles:
     - linux-system-roles.firewall


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.
