### PR TITLE
fix: state not required for masquerade and ICMP block inversion

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
     target: "{{ item.target | default(omit) }}"
     permanent: "{{ item.permanent | default(True) }}"
     runtime: "{{ item.runtime | default(True) }}"
-    state: "{{ item.state }}"
+    state: "{{ item.state | default(omit) }}"
     __report_changed: "{{ not __firewall_previous_replaced }}"
   loop: "{{ firewall is mapping | ternary([firewall], firewall) |
     map('dict2items') | map('difference', __previous) | select |

--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -200,7 +200,6 @@
       - name: Allow masquerading in permament dmz zone
         firewall_lib:
           masquerade: yes
-          state: enabled
           permanent: yes
           zone: dmz
         register: result
@@ -209,7 +208,6 @@
       - name: Allow masquerading in permament dmz zone, again
         firewall_lib:
           masquerade: yes
-          state: enabled
           permanent: yes
           zone: dmz
         register: result
@@ -226,7 +224,6 @@
       - name: Ensure ICMP block inversion in permanent drop zone
         firewall_lib:
           zone: drop
-          state: enabled
           permanent: yes
           icmp_block_inversion: yes
         register: result
@@ -235,7 +232,6 @@
       - name: Ensure ICMP block inversion in permanent drop zone, again
         firewall_lib:
           zone: drop
-          state: enabled
           permanent: yes
           icmp_block_inversion: yes
         register: result

--- a/tests/tests_purge_config.yml
+++ b/tests/tests_purge_config.yml
@@ -18,7 +18,6 @@
                        '448/tcp;;1.2.3.5']
         state: enabled
       - masquerade: yes
-        state: enabled
       - service: http
         state: enabled
   tasks:
@@ -113,7 +112,6 @@
           vars:
             firewall:
               - set_default_zone: dmz
-                state: enabled
 
         - name: Verify role reports changed
           fail:
@@ -126,7 +124,6 @@
           vars:
             firewall:
               - set_default_zone: dmz
-                state: enabled
 
         - name: Verify role reports not changed
           fail:
@@ -140,7 +137,6 @@
             firewall:
               - previous: replaced
               - set_default_zone: dmz
-                state: enabled
 
         - name: Verify role reports not changed
           fail:

--- a/tests/tests_target.yml
+++ b/tests/tests_target.yml
@@ -8,7 +8,6 @@
           vars:
             firewall:
               - set_default_zone: public
-                state: enabled
                 permanent: yes
               - target: DROP
                 state: enabled

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -384,6 +384,14 @@ class FirewallLibMain(unittest.TestCase):
         )
 
     @patch("firewall_lib.HAS_FIREWALLD", True)
+    def test_main_error_state_required_for_options(self, am_class):
+        am = am_class.return_value
+        am.params = {"permanent": True, "source": ["192.0.2.0/24"]}
+        with self.assertRaises(MockException):
+            firewall_lib.main()
+        am.fail_json.assert_called_with(msg="Options invalid without state option set")
+
+    @patch("firewall_lib.HAS_FIREWALLD", True)
     def test_main_error_timeout_icmp_block_inversion(self, am_class):
         am = am_class.return_value
         am.params = {"icmp_block_inversion": True, "timeout": 1}


### PR DESCRIPTION
- The above, and added a new error message for attempting to not specify state when using options that require state like source, port, port_forward

 - Unit test case added for this error message

- Removed state option from integration tests for masquerading and ICMP block, retaining the same fail conditions

Fixes: #76