### PR TITLE
make all tests work with gather_facts: false

### DIFF
--- a/tests/tests_zone.yml
+++ b/tests/tests_zone.yml
@@ -1,6 +1,7 @@
 - name: Test firewalld zones
   hosts: all
   become: true
+  gather_facts: true
   tasks:
     - name: Test firewalld zones
       block:


### PR DESCRIPTION
The tests_zone.yml test uses facts outside of the role and
needs to `gather_facts: true` when using ANSIBLE_GATHERING=explicit
