### PR TITLE
bugfix: port forward dict form works

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,14 @@ Add or remove port forwarding for ports or port ranges for a zone. It takes two
 different formats:
 * string or a list of strings in the format like `firewall-cmd
   --add-forward-port` e.g. `<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]`
-* list of dicts in the format like `ansible.posix.firewalld`:
+* dict or list of dicts in the format like `ansible.posix.firewalld`:
 
-NOTE: single dict form for `forward_port` is not supported by the system role.
-
-```
+```yaml
 forward_port:
-  - port: <port>
-    proto: <protocol>
-    [toport: <to-port>]
-    [toaddr: <to-addr>]
+  port: <port>
+  proto: <protocol>
+  [toport: <to-port>]
+  [toaddr: <to-addr>]
 ```
 examples
 ```yaml

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ different formats:
   --add-forward-port` e.g. `<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]`
 * list of dicts in the format like `ansible.posix.firewalld`:
 
-NOTE: single dict form is not supported by the system role.
+NOTE: single dict form for `forward_port` is not supported by the system role.
 
 ```
 forward_port:

--- a/README.md
+++ b/README.md
@@ -140,19 +140,24 @@ Add or remove port forwarding for ports or port ranges for a zone. It takes two
 different formats:
 * string or a list of strings in the format like `firewall-cmd
   --add-forward-port` e.g. `<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]`
-* dict or list of dicts in the format like `ansible.posix.firewalld`:
+* list of dicts in the format like `ansible.posix.firewalld`:
+
+NOTE: single dict form is not supported by the system role.
 
 ```
 forward_port:
-  port: <port>
-  proto: <protocol>
-  [toport: <to-port>]
-  [toaddr: <to-addr>]
+  - port: <port>
+    proto: <protocol>
+    [toport: <to-port>]
+    [toaddr: <to-addr>]
 ```
 examples
-```
+```yaml
 forward_port: '447/tcp;;1.2.3.4'
 forward_port: ['447/tcp;;1.2.3.4','448/tcp;;1.2.3.5']
+forward_port:
+  - 447/tcp;;1.2.3.4
+  - 448/tcp;;1.2.3.5
 forward_port:
   - port: 447
     proto: tcp

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -65,12 +65,13 @@ options:
   forward_port:
     description:
       List of forward port strings.
+      Elements must be str or dict.
       The format of a forward port needs to be
       <port>[-<port>]/<protocol>;[<to-port>];[<to-addr>].
     aliases: ["port_forward"]
     required: false
     type: list
-    elements: str
+    elements: raw
   masquerade:
     description:
       The masquerade bool setting.
@@ -390,7 +391,7 @@ def parse_forward_port(module, item):
         else:
             _to_port = None
         _to_addr = item.get("toaddr")
-    else:
+    elif isinstance(item, str):
         args = item.split(";")
         if len(args) == 3:
             __port, _to_port, _to_addr = args
@@ -404,6 +405,10 @@ def parse_forward_port(module, item):
             _to_port = None
         if _to_addr == "":
             _to_addr = None
+    else:
+        module.fail_json(
+            msg="improper %s type (must be str or dict): %s" % (type_string, item)
+        )
 
     return (_port, _protocol, _to_port, _to_addr)
 
@@ -421,7 +426,7 @@ def main():
             forward_port=dict(
                 required=False,
                 type="list",
-                elements="str",
+                elements="raw",
                 default=[],
                 aliases=["port_forward"],
                 deprecated_aliases=[

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -64,14 +64,13 @@ options:
     elements: str
   forward_port:
     description:
-      List of forward port strings.
-      Elements must be str or dict.
-      The format of a forward port needs to be
+      List of forward port strings or dicts,
+      or a single string or dict.
+      The format of a forward port string needs to be
       <port>[-<port>]/<protocol>;[<to-port>];[<to-addr>].
     aliases: ["port_forward"]
     required: false
-    type: list
-    elements: raw
+    type: raw
   masquerade:
     description:
       The masquerade bool setting.
@@ -370,6 +369,14 @@ def parse_helper_module(module, item):
     return "_".join(_module)
 
 
+def get_forward_port(module):
+    forward_port = module.params["forward_port"]
+    if isinstance(forward_port, list):
+        return forward_port
+    else:
+        return [forward_port]
+
+
 def parse_forward_port(module, item):
     type_string = "forward_port"
 
@@ -425,8 +432,7 @@ def main():
             source_port=dict(required=False, type="list", elements="str", default=[]),
             forward_port=dict(
                 required=False,
-                type="list",
-                elements="raw",
+                type="raw",
                 default=[],
                 aliases=["port_forward"],
                 deprecated_aliases=[
@@ -502,7 +508,7 @@ def main():
     for port_proto in module.params["source_port"]:
         source_port.append(parse_port(module, port_proto))
     forward_port = []
-    for item in module.params["forward_port"]:
+    for item in get_forward_port(module):
         forward_port.append(parse_forward_port(module, item))
     masquerade = module.params["masquerade"]
     rich_rule = []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,8 @@
     service: "{{ item.service | default(omit) }}"
     port: "{{ item.port | default(omit) }}"
     source_port: "{{ item.source_port | default(omit) }}"
-    forward_port: "{{ item.forward_port | default(omit) }}"
+    forward_port: "{{ (item.forward_port is mapping) |
+      ternary([item.forward_port], item.forward_port) | default(omit) }}"
     masquerade: "{{ item.masquerade | default(omit) }}"
     rich_rule: "{{ item.rich_rule | default(omit) }}"
     source: "{{ item.source | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,8 +44,7 @@
     service: "{{ item.service | default(omit) }}"
     port: "{{ item.port | default(omit) }}"
     source_port: "{{ item.source_port | default(omit) }}"
-    forward_port: "{{ (item.forward_port is mapping) |
-      ternary([item.forward_port], item.forward_port) | default(omit) }}"
+    forward_port: "{{ item.forward_port | default(omit) }}"
     masquerade: "{{ item.masquerade | default(omit) }}"
     rich_rule: "{{ item.rich_rule | default(omit) }}"
     source: "{{ item.source | default(omit) }}"

--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -539,7 +539,7 @@
         register: result
         failed_when: result is failed or result is changed
 
-      - name: diable forward port (string)
+      - name: disable forward port (string)
         firewall_lib:
           forward_port: 40/tcp;8080;0.0.0.0
           state: disabled
@@ -557,7 +557,7 @@
         register: result
         failed_when: result is failed or result is not changed
 
-      - name: forward port again (list-dict form)
+      - name: forward port again (dict form)
         firewall_lib:
           forward_port:
             - port: 40

--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -549,10 +549,10 @@
       - name: forward port (dict form)
         firewall_lib:
           forward_port:
-            - port: 40
-              proto: tcp
-              toport: 8080
-              toaddr: 0.0.0.0
+            port: 40
+            proto: tcp
+            toport: 8080
+            toaddr: 0.0.0.0
           state: enabled
         register: result
         failed_when: result is failed or result is not changed

--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -525,6 +525,60 @@
         register: result
         failed_when: result is failed or result is changed
 
+      - name: forward port 40 to 0.0.0.0:8080 (string)
+        firewall_lib:
+          forward_port: 40/tcp;8080;0.0.0.0
+          state: enabled
+        register: result
+        failed_when: result is failed or result is not changed
+
+      - name: forward same port again (string)
+        firewall_lib:
+          forward_port: 40/tcp;8080;0.0.0.0
+          state: enabled
+        register: result
+        failed_when: result is failed or result is changed
+
+      - name: diable forward port (string)
+        firewall_lib:
+          forward_port: 40/tcp;8080;0.0.0.0
+          state: disabled
+        register: result
+        failed_when: result is failed or result is not changed
+
+      - name: forward port (dict form)
+        firewall_lib:
+          forward_port:
+            - port: 40
+              proto: tcp
+              toport: 8080
+              toaddr: 0.0.0.0
+          state: enabled
+        register: result
+        failed_when: result is failed or result is not changed
+
+      - name: forward port again (list-dict form)
+        firewall_lib:
+          forward_port:
+            - port: 40
+              proto: tcp
+              toport: 8080
+              toaddr: 0.0.0.0
+          state: enabled
+        register: result
+        failed_when: result is failed or result is changed
+
+      - name: disable forward port (dict form)
+        firewall_lib:
+          forward_port:
+            - port: 40
+              proto: tcp
+              toport: 8080
+              toaddr: 0.0.0.0
+          state: disabled
+        register: result
+        failed_when: result is failed or result is not changed
+
     always:
 
       - name: Cleanup

--- a/tests/tests_forward_port.yml
+++ b/tests/tests_forward_port.yml
@@ -29,10 +29,10 @@
       vars:
         firewall:
           - forward_port:
-              - port: 40
-                proto: tcp
-                toport: 8080
-                toaddr: 0.0.0.0
+              port: 40
+              proto: tcp
+              toport: 8080
+              toaddr: 0.0.0.0
             state: enabled
           - forward_port:
               - port: 40

--- a/tests/tests_forward_port.yml
+++ b/tests/tests_forward_port.yml
@@ -1,0 +1,44 @@
+---
+- name: Test forward port
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Clean slate
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall:
+          previous: replaced
+
+    # Tests string and dict form types
+
+    - name: forward_port and undo (string)
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall:
+          - forward_port: 40/tcp;8080;0.0.0.0
+            state: enabled
+          - forward_port: 40/tcp;8080;0.0.0.0
+            state: disabled
+
+    - name: forward_port (dict) and undo
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall:
+          - forward_port:
+              port: 40
+              proto: tcp
+              toport: 8080
+              toaddr: 0.0.0.0
+            state: enabled
+          - forward_port:
+              - port: 40
+                proto: tcp
+                toport: 8080
+                toaddr: 0.0.0.0
+            state: disabled
+
+...

--- a/tests/tests_forward_port.yml
+++ b/tests/tests_forward_port.yml
@@ -29,10 +29,10 @@
       vars:
         firewall:
           - forward_port:
-              port: 40
-              proto: tcp
-              toport: 8080
-              toaddr: 0.0.0.0
+              - port: 40
+                proto: tcp
+                toport: 8080
+                toaddr: 0.0.0.0
             state: enabled
           - forward_port:
               - port: 40


### PR DESCRIPTION
- fixed bug where port_forward argument only worked with string argument

 - additionally argument converts to list if necessary

- minimal tests added for port forward

 - tests_port_forward.yml only has the fail case that the role fails

Fixes: #85