### PR TITLE
Add/remove interfaces to zone using PCI device ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,62 @@ source: 192.0.2.0/24
 
 String or list of interface name strings.
 
-```
+```yaml
 interface: eth2
 ```
+
+This role handles interface arguments similar to
+how firewalld's cli, `firewall-cmd` does, i.e.
+manages the interface through NetworkManger if possible,
+and handles the interface binding purely through firewalld
+otherwise.
+
+```
+WARNING: Neither firewalld nor this role throw any
+errors if the interface name specified is not
+tied to any existing network interface. This can cause confusion
+when attempting to add an interface via PCI device ID,
+for which you should use the parameter `interface_pci_id`
+instead of the `interface` parameter.
+
+Allow interface named '8086:15d7' in dmz zone
+
+firewall:
+  - zone: dmz
+    interface: 8086:15d7
+    state: enabled
+
+The above will successfully add a nftables/iptables rule
+for an interface named `8086:15d7`, but no traffic should/will
+ever match to an interface with this name.
+
+TLDR - When using this parameter, please stick only to using
+logical interface names that you know exist on the device to 
+avoid confusing behavior.
+```
+
+### interface_pci_id
+
+String or list of interface PCI device IDs.
+Accepts PCI IDs if the wildcard `XXXX:YYYY` applies
+where:
+- XXXX: Hexadecimal, corresponds to Vendor ID
+- YYYY: Hexadecimal, corresponds to Device ID
+
+```yaml
+# PCI id for Intel Corporation Ethernet Connection
+interface_pci_id: 8086:15d7
+```
+
+Only accepts PCI devices IDs that correspond to a named network interface,
+and converts all PCI device IDs to their respective logical interface names.
+
+If a PCI id corresponds to more than one logical interface name,
+all interfaces with the PCI id specified will have the play applied.
+
+A list of PCI devices with their IDs can be retrieved using `lcpci -nn`.
+For more information on PCI device IDs, see the linux man page at:
+https://man7.org/linux/man-pages/man5/pci.ids.5.html
 
 ### icmp_block
 
@@ -418,6 +471,14 @@ Do not permit traffic in default zone for https service:
 firewall:
   - service: https
     state: disabled
+```
+
+Allow interface with PCI device ID '8086:15d7' in dmz zone
+```yaml
+firewall:
+  - zone: dmz
+    interface_pci_id: 8086:15d7
+    state: enabled
 ```
 
 Example Playbooks

--- a/tests/tests_interface_pci.yml
+++ b/tests/tests_interface_pci.yml
@@ -1,0 +1,79 @@
+---
+# Tests interface_pci field, test must be used in VM
+- name: Test interfaces with PCI ids
+  hosts: all
+  become: true
+  roles:
+    - linux-system-roles.firewall
+
+  tasks:
+    - name: get backend from dbus
+      command: >-
+        dbus-send --system --print-reply --type=method_call
+        --dest=org.fedoraproject.FirewallD1
+        /org/fedoraproject/FirewallD1/config
+        org.freedesktop.DBus.Properties.Get
+        string:"org.fedoraproject.FirewallD1.config"
+        string:"FirewallBackend"
+      ignore_errors: yes
+      register: result
+
+    - name: get backend from result
+      set_fact:
+        nftables_backend:
+          "{{ result is not failed and 'nftables' in result.stdout }}"
+
+    - name: test interfaces with PCI ids
+      block:
+        - name: add pci device ethernet controller
+          include_role:
+            name: linux-system-roles.firewall
+          vars:
+            firewall:
+              zone: internal
+              interface_pci_id: 1af4:0001
+              state: enabled
+              permanent: yes
+
+        - name: add pci device again
+          include_role:
+            name: linux-system-roles.firewall
+          vars:
+            firewall:
+              zone: internal
+              interface_pci_id: 1af4:0001
+              state: enabled
+              permanent: yes
+
+        - name: assert pcid not in nftable ruleset
+          command: nft list ruleset
+          register: result
+          failed_when: result is failed or '1af4:0001' in result.stdout
+          when: nftables_backend | bool
+
+        - name: assert pcid not in iptables rules
+          command: iptables -S
+          register: result
+          failed_when: result is failed or '1af4:0001' in result.stdout
+          when: not nftables_backend | bool
+
+        - name: remove interface from internal
+          include_role:
+            name: linux-system-roles.firewall
+          vars:
+            firewall:
+              zone: internal
+              interface_pci_id: 1af4:0001
+              state: disabled
+              permament: yes
+      always:
+        - name: Cleanup
+          tags:
+            - tests::cleanup
+          include_role:
+            name: linux-system-roles.firewall
+          vars:
+            firewall:
+              - previous: replaced
+
+...


### PR DESCRIPTION
- Add/remove interfaces to a zone using PCI ID (formatted XXXX:XXXX, VendorID:DeviceID)
  - Collision of interfaces with the same PCI ID (while unlikely) is handled by applying the play to each interface with the PCI id
  - fixes RHBZ 2100939
  - Useful as it allows control nodes to manage interfaces by what a device is rather than what interface name it was assigned.
- Added Network Manger interfacing in the same capacity to which firewall-cmd interacts with Network Manager for interfaces
  - See `--[add/remove/change]-interface`  at https://firewalld.org/documentation/man-pages/firewall-cmd.html