### PR TITLE
Added some example playbooks

### DIFF
--- a/examples/disable-cockpit-and-dhcpv6-client.yml
+++ b/examples/disable-cockpit-and-dhcpv6-client.yml
@@ -1,5 +1,5 @@
 ---
-- name: Enable http and https service in default zone
+- name: Disable cockpit and dhcpv6-client service in default zone
   hosts: "{{ targets }}"
 
   vars:

--- a/examples/disable-cockpit-and-dhcpv6-client.yml
+++ b/examples/disable-cockpit-and-dhcpv6-client.yml
@@ -1,0 +1,10 @@
+---
+- name: Enable http and https service in default zone
+  hosts: "{{ targets }}"
+
+  vars:
+    firewall:
+      - service: [cockpit,dhcpv6-client]
+        state: disabled
+  roles:
+    - linux-system-roles.firewall

--- a/examples/disable-cockpit-and-dhcpv6-client.yml
+++ b/examples/disable-cockpit-and-dhcpv6-client.yml
@@ -4,7 +4,7 @@
 
   vars:
     firewall:
-      - service: [cockpit,dhcpv6-client]
+      - service: [cockpit, dhcpv6-client]
         state: disabled
   roles:
     - linux-system-roles.firewall

--- a/examples/enable-http-and-https.yml
+++ b/examples/enable-http-and-https.yml
@@ -4,7 +4,7 @@
 
   vars:
     firewall:
-      - service: [http,https]
+      - service: [http, https]
         state: enabled
   roles:
     - linux-system-roles.firewall

--- a/examples/enable-http-and-https.yml
+++ b/examples/enable-http-and-https.yml
@@ -1,0 +1,10 @@
+---
+- name: Enable http and https service in default zone
+  hosts: "{{ targets }}"
+
+  vars:
+    firewall:
+      - service: [http,https]
+        state: enabled
+  roles:
+    - linux-system-roles.firewall

--- a/examples/enable-ssh-only.yml
+++ b/examples/enable-ssh-only.yml
@@ -1,0 +1,11 @@
+---
+- name: Erase existing config and enable ssh service
+  hosts: "{{ targets }}"
+
+  vars:
+    firewall:
+      - previous: replaced
+      - service: ssh
+        state: enabled
+  roles:
+    - linux-system-roles.firewall


### PR DESCRIPTION
IMHO it's useful to have some example playbooks for common use cases that are easy to adapt by copy, paste, and modify.

I like it when roles have an example direktory with some playbooks in it, because it saves time when I don't have to search a long README.md for some examples.

With this PR I would like to contribute some example playbooks for the firewall role. I chose some use cases I encountered in different enviroments.

Signed-off-by: Joerg Kastning <jkastning@my-it-brain.de>