### PR TITLE
cannot use distutils; use custom version

### DIFF
--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -1,0 +1,4 @@
+plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib.py validate-modules:missing-examples
+roles/firewall/files/get_files_checksums.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,0 +1,4 @@
+plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib.py validate-modules:missing-examples
+roles/firewall/files/get_files_checksums.sh shebang!skip

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -210,7 +210,6 @@ options:
     default: true
 """
 
-from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 import re
 import os
@@ -247,6 +246,22 @@ except ImportError:
 
 
 PCI_REGEX = re.compile("[0-9a-fA-F]{4}:[0-9a-fA-F]{4}")
+
+
+# NOTE: Because of PEP632, we cannot use distutils.
+# In addition, because of the wide range of python
+# versions we have to support, there isn't a good
+# version parser across all of them, that is provided
+# with Ansible.
+def lsr_parse_version(v_str):
+    v_ary = v_str.split(".")
+    v = []
+    for v_ary_str in v_ary:
+        try:
+            v.append(int(v_ary_str))
+        except ValueError:
+            v.append(0)
+    return v
 
 
 def try_get_connection_of_interface(interface):
@@ -832,7 +847,7 @@ def main():
         permanent = True
 
         # Pre-run version checking
-        if LooseVersion(FW_VERSION) < LooseVersion("0.3.9"):
+        if lsr_parse_version(FW_VERSION) < lsr_parse_version("0.3.9"):
             module.fail_json(
                 msg="Unsupported firewalld version %s" " requires >= 0.3.9" % FW_VERSION
             )
@@ -851,7 +866,7 @@ def main():
         fw.start()
     else:
         # Pre-run version checking
-        if LooseVersion(FW_VERSION) < LooseVersion("0.2.11"):
+        if lsr_parse_version(FW_VERSION) < lsr_parse_version("0.2.11"):
             module.fail_json(
                 msg="Unsupported firewalld version %s, requires >= 0.2.11" % FW_VERSION
             )

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -717,3 +717,27 @@ def test_module_parameters(method, state, input, expected):
         has_fw_patcher.stop()
         fw_ver_patcher.stop()
         rich_rule_patcher.stop()
+
+
+class FirewallVersionTest(unittest.TestCase):
+    """class to test lsr_parse_version"""
+
+    def test_lsr_parse_version(self):
+        ver = firewall_lib.lsr_parse_version("")
+        assert ver == [0]
+        ver = firewall_lib.lsr_parse_version("a.b")
+        assert ver == [0, 0]
+        ver = firewall_lib.lsr_parse_version("1")
+        assert ver == [1]
+        ver = firewall_lib.lsr_parse_version("1.2")
+        assert ver == [1, 2]
+        ver = firewall_lib.lsr_parse_version("1.2.3")
+        assert ver == [1, 2, 3]
+        ver = firewall_lib.lsr_parse_version("1.2.3.4")
+        assert ver == [1, 2, 3, 4]
+        ver_b = firewall_lib.lsr_parse_version("0.3")
+        assert ver_b < ver
+        ver_b = firewall_lib.lsr_parse_version("1.2.3")
+        assert ver_b < ver
+        ver_b = firewall_lib.lsr_parse_version("1.2.4")
+        assert ver_b > ver


### PR DESCRIPTION
distutils is deprecated, and ansible-lint 2.14 throws an error about this.
There isn't really a suitable version parser replacement that works
without additional dependencies across python 2.7 - 3.11.  So, write
our own version parser.
