### PR TITLE
add contents: write permission for branch push

### DIFF
--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      contents: write
     steps:
       - name: Update pip, git
         run: |


### PR DESCRIPTION
Need `contents: write` permission for branch push for weekly ci job

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
