### PR TITLE
fix: Don't install python(3)-firewall it's a dependency of firewalld

### DIFF
--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -9,15 +9,3 @@
   package:
     name: "{{ __firewall_packages_base }}"
     state: present
-
-- name: Install python-firewall
-  package:
-    name: "{{ __firewall_packages_python2 }}"
-    state: present
-  when: ansible_python_version is version('3', '<')
-
-- name: Install python3-firewall
-  package:
-    name: "{{ __firewall_packages_python3 }}"
-    state: present
-  when: ansible_python_version is version('3', '>=')

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,7 +8,5 @@ __firewall_required_facts:
   - python_version
 
 __firewall_packages_base: [firewalld]
-__firewall_packages_python2: [python-firewall]
-__firewall_packages_python3: [python3-firewall]
 
 __firewall_service: firewalld


### PR DESCRIPTION
Enhancement: The role now does not run tasks to install python-firewall or python3-firewall based on installed python version.

Reason:  python-firewall or python3-firewall is pulled automatically by dnf and yum when installing firewalld.
The issue is that when I install python3 on EL 7, the role then fails with "No package matching 'python3-firewall' found available, installed or updated". It sees python3 present on the system and tries to install python3-firewall, which is not available on EL 7.

Result: The role doesn't fail on EL 7 when python3 is installed on the managed node.
