### PR TITLE
fix: make enabling/disabling non-existent services not fail in check mode

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -16,6 +16,7 @@ kinds:
   - playbook: "**/examples/*.yml"
 skip_list:
   - fqcn-builtins
+  - var-naming[no-role-prefix]
 exclude_paths:
   - tests/roles/
   - .github/

--- a/README.md
+++ b/README.md
@@ -232,13 +232,15 @@ zone: public
 
 ### service
 
-Name of a service or service list to add or remove inbound access to. The
-service needs to be defined in firewalld.
+Name of a service or service list to add or remove inbound access to.
 
 ```yaml
 service: ftp
 service: [ftp,tftp]
 ```
+
+If a specified service does not exist in firewalld, the module will fail in diff mode, 
+and when run in check mode will always report no changes and warn the user of the potential for failure.
 
 ###### User defined services
 

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -327,7 +327,7 @@
         - name: Fail if enabling non-existent service in check mode registers changes
           fail:
             msg: enabling/disabling non-existent service in check mode resulted in changes
-          when: firewall_lib_result.changed
+          when: firewall_lib_result.changed  # noqa no-handler
 
       always:
         - name: Cleanup

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -324,10 +324,12 @@
                     zone: public
                     permanent: true
 
-        - name: Fail if enabling non-existent service in check mode registers changes
+        - name: Fail if enabling service in check mode causes changes 
           fail:
-            msg: enabling/disabling non-existent service in check mode resulted in changes
-          when: firewall_lib_result.changed  # noqa no-handler
+            msg: >-
+              enabling/disabling non-existent service in check mode 
+                resulted in changes
+          when: firewall_lib_result.changed
 
       always:
         - name: Cleanup

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -314,7 +314,7 @@
         - name: Try to add a service that does not exist in check mode
           check_mode: true
           block:
-            - name: attempt to enable http-alt, which does not exist
+            - name: Attempt to enable http-alt, which does not exist
               include_role:
                 name: linux-system-roles.firewall
               vars:

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -324,7 +324,7 @@
                     zone: public
                     permanent: true
 
-        - name: Fail if enabling service in check mode causes changes
+        - name: Fail if enabling service in check mode reports changes
           fail:
             msg: >-
               enabling/disabling non-existent service in check mode

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -309,7 +309,7 @@
         - name: Fail if second removal changes anything
           fail:
             msg: something changed when systemrole test removed
-          when: firewall_lib_result.changed
+          when: firewall_lib_result.changed  # noqa no-handler
 
         - name: Try to add a service that does not exist in check mode
           check_mode: true

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -329,7 +329,7 @@
             msg: >-
               enabling/disabling non-existent service in check mode 
                 resulted in changes
-          when: firewall_lib_result.changed
+          when: firewall_lib_result.changed  # noqa no-handler
 
       always:
         - name: Cleanup

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -324,7 +324,7 @@
                     zone: public
                     permanent: true
 
-        - name: Fail if enabling service in check mode causes changes 
+        - name: Fail if enabling service in check mode causes changes
           fail:
             msg: >-
               enabling/disabling non-existent service in check mode 

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -311,6 +311,24 @@
             msg: something changed when systemrole test removed
           when: firewall_lib_result.changed  # noqa no-handler
 
+        - name: Try to add a service that does not exist in check mode
+          check_mode: true
+          block:
+            - name: attempt to enable http-alt, which does not exist
+              include_role:
+                name: linux-system-roles.firewall
+              vars:
+                firewall:
+                  - service: http-alt
+                    state: enabled
+                    zone: public
+                    permanent: true
+
+        - name: Fail if enabling non-existent service in check mode registers changes
+          fail:
+            msg: enabling/disabling non-existent service in check mode resulted in changes
+          when: firewall_lib_result.changed
+
       always:
         - name: Cleanup
           tags:

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -328,7 +328,7 @@
           fail:
             msg: >-
               enabling/disabling non-existent service in check mode
-                resulted in changes
+              resulted in changes
           when: firewall_lib_result.changed  # noqa no-handler
 
       always:

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -309,7 +309,7 @@
         - name: Fail if second removal changes anything
           fail:
             msg: something changed when systemrole test removed
-          when: firewall_lib_result.changed  # noqa no-handler
+          when: firewall_lib_result.changed
 
         - name: Try to add a service that does not exist in check mode
           check_mode: true

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -327,7 +327,7 @@
         - name: Fail if enabling service in check mode causes changes
           fail:
             msg: >-
-              enabling/disabling non-existent service in check mode 
+              enabling/disabling non-existent service in check mode
                 resulted in changes
           when: firewall_lib_result.changed  # noqa no-handler
 

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -40,7 +40,9 @@ TEST_DATA = {
         "input": {"service": SERVICES_PRESENT},
         "enabled": {
             "expected": {
-                "runtime": [call("default", service, 0) for service in SERVICES_PRESENT],
+                "runtime": [
+                    call("default", service, 0) for service in SERVICES_PRESENT
+                ],
                 "permanent": [call(service) for service in SERVICES_PRESENT],
             }
         },

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -34,27 +34,20 @@ TEST_METHODS = [
     "Target",
 ]
 TEST_STATES = ["enabled", "disabled"]
+SERVICES_PRESENT = ["https", "ipsec", "ldaps"]
 TEST_DATA = {
     "Service": {
-        "input": {"service": ["https", "ipsec", "ldaps"]},
+        "input": {"service": SERVICES_PRESENT},
         "enabled": {
             "expected": {
-                "runtime": [
-                    call("default", "https", 0),
-                    call("default", "ipsec", 0),
-                    call("default", "ldaps", 0),
-                ],
-                "permanent": [call("https"), call("ipsec"), call("ldaps")],
+                "runtime": [call("default", service, 0) for service in SERVICES_PRESENT],
+                "permanent": [call(service) for service in SERVICES_PRESENT],
             }
         },
         "disabled": {
             "expected": {
-                "runtime": [
-                    call("default", "https"),
-                    call("default", "ipsec"),
-                    call("default", "ldaps"),
-                ],
-                "permanent": [call("https"), call("ipsec"), call("ldaps")],
+                "runtime": [call("default", service) for service in SERVICES_PRESENT],
+                "permanent": [call(service) for service in SERVICES_PRESENT],
             }
         },
     },
@@ -692,6 +685,7 @@ def test_module_parameters(method, state, input, expected):
         fw.getDefaultZone = Mock(return_value="default")
         fw_config = Mock()
         fw.config.return_value = fw_config
+        fw_config.getServiceNames.return_value = SERVICES_PRESENT
         fw_zone = Mock()
         fw_config.getZoneByName.return_value = fw_zone
         fw_settings = Mock()

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -635,6 +635,35 @@ class FirewallLibMain(unittest.TestCase):
         firewall_lib.set_the_default_zone()
         firewall_lib.set_the_default_zone.assert_called()
 
+    @patch("firewall_lib.HAS_FIREWALLD", True)
+    @patch("firewall_lib.FW_VERSION", "0.3.8", create=True)
+    @patch("firewall_lib.FirewallClient", create=True)
+    def test_main_error_enable_undefined_service(self, fw_class, am_class):
+        am = am_class.return_value
+        am.params = {
+            "service": ["http-alt"],
+            "state": "enabled",
+        }
+        with self.assertRaises(MockException):
+            firewall_lib.main()
+        am.fail_json.assert_called_with(msg="INVALID SERVICE - http-alt")
+
+    # @patch("firewall_lib.HAS_FIREWALLD", True)
+    # @patch("firewall_lib.FW_VERSION", "0.3.8", create=True)
+    # @patch("firewall_lib.FirewallClient", create=True)
+    # def test_main_warning_enable_undefined_service_in_check_mode(self, fw_class, am_class):
+    #     am_class.check_mode = True
+    #     am = am_class.return_value
+    #     am.params = {
+    #         "service": ["http-alt"],
+    #         "state": "enabled",
+    #     }
+    #     firewall_lib.main()
+    #     am.warn.assert_called_with(
+    #         "Service does not exist - http-alt."
+    #         + " Ensure that you define the service in the playbook before running it in diff mode"
+    #     )
+
 
 @pytest.mark.parametrize("method,state,input,expected", TEST_PARAMS)
 def test_module_parameters(method, state, input, expected):

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -271,6 +271,24 @@ class MockAnsibleModule(MagicMock):
         return am
 
 
+class MockAnsibleModuleCheckMode(MagicMock):
+    def __call__(self, **kwargs):
+        am = self.return_value
+        am.call_params = {}
+        if not isinstance(am.params, dict):
+            am.params = {}
+        for kk, vv in kwargs["argument_spec"].items():
+            am.call_params[kk] = vv.get("default")
+            if kk not in am.params:
+                am.params[kk] = am.call_params[kk]
+        am.supports_check_mode = kwargs["supports_check_mode"]
+        am.fail_json = Mock(side_effect=MockException())
+        am.exit_json = Mock()
+        am.warn = Mock()
+        am.check_mode = True
+        return am
+
+
 class FirewallInterfaceTests(unittest.TestCase):
     """class to test Firewall interface tests"""
 
@@ -648,21 +666,38 @@ class FirewallLibMain(unittest.TestCase):
             firewall_lib.main()
         am.fail_json.assert_called_with(msg="INVALID SERVICE - http-alt")
 
-    # @patch("firewall_lib.HAS_FIREWALLD", True)
-    # @patch("firewall_lib.FW_VERSION", "0.3.8", create=True)
-    # @patch("firewall_lib.FirewallClient", create=True)
-    # def test_main_warning_enable_undefined_service_in_check_mode(self, fw_class, am_class):
-    #     am_class.check_mode = True
-    #     am = am_class.return_value
-    #     am.params = {
-    #         "service": ["http-alt"],
-    #         "state": "enabled",
-    #     }
-    #     firewall_lib.main()
-    #     am.warn.assert_called_with(
-    #         "Service does not exist - http-alt."
-    #         + " Ensure that you define the service in the playbook before running it in diff mode"
-    #     )
+
+@patch("firewall_lib.AnsibleModule", new_callable=MockAnsibleModuleCheckMode)
+class FirewallLibMainCheckMode(unittest.TestCase):
+    """Test main function."""
+
+    @patch("firewall_lib.HAS_FIREWALLD", True)
+    @patch("firewall_lib.FW_VERSION", "0.3.8", create=True)
+    @patch("firewall_lib.FirewallClient", create=True)
+    def test_main_warning_enable_undefined_service_in_check_mode(
+        self, fw_class, am_class
+    ):
+        am = am_class.return_value
+        am.params = {
+            "service": ["http-alt"],
+            "state": "enabled",
+        }
+
+        fw = fw_class.return_value
+        fw.connected = True
+        fw.getDefaultZone = Mock(return_value="default")
+        fw_config = Mock()
+        fw.config.return_value = fw_config
+        fw_config.getServiceNames.return_value = SERVICES_PRESENT
+        fw_zone = Mock()
+        fw_config.getZoneByName.return_value = fw_zone
+        fw_settings = Mock()
+        fw_zone.getSettings.return_value = fw_settings
+        firewall_lib.main()
+        am.warn.assert_called_with(
+            "Service does not exist - http-alt."
+            + " Ensure that you define the service in the playbook before running it in diff mode"
+        )
 
 
 @pytest.mark.parametrize("method,state,input,expected", TEST_PARAMS)


### PR DESCRIPTION
Enhancement:
- firewall_lib.py - check if service exists before running firewalld methods that would cause failure
  - fails if service does not exist and in diff mode, warns if in check mode and service does not exist
- README.md - reflects changes and explains interaction with check mode
- tests/tests_service.yml - add integration test case for adding non-existent services in check mode
- tests/unit/test_firewall_lib.py - Mock necessary output from fw.config().getServiceNames()

Reason:
Better compliance with Ansible best practices for check mode (not failing in check mode, especially where they would not fail in diff mode)
Reason for this particular solution - We cannot track changes from previous check modes without overhauling how check mode is handled throughout the entire system role. 

Result:
Undefined services being enabled or disabled will not result in failure while in check mode, but a warning will be displayed intended to prompt the user to confirm that the service is defined in a previous play, since the same action could result in failure when run in diff mode.

Issue Tracker Tickets (Jira or BZ if any):
- Addresses GitHub Issue #146
