### PR TITLE
fix: unmask firewalld on run, disable conflicting services

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ If firewalld is not in use, the role will install (if not already installed),
 unmask, and enable firewalld.
 
 The role can also attempt to disable known conflicting services.
-The list of known conflicting services can be found in `vars/main.yml`,
-please sumbit an issue if there are any unaccounted-for services.
 
 For the configuration the role uses the firewalld client interface
 which is available in RHEL-7 and later.
@@ -201,9 +199,10 @@ permanent change was made to each setting:
 
 Variables
 ---------
+
 ## firewall_disable_conflicting_services
 
-By default, the firewall role does not attempt to disable conflicting services such as `nftables.service` due to the
+By default, the firewall role does not attempt to disable conflicting services due to the
 overhead associated with enumerating the services when disabling services is potentially unecessary.
 To enable this feature, set the variable `firewall_disable_conflicting_services` to `true`:
 
@@ -214,6 +213,13 @@ To enable this feature, set the variable `firewall_disable_conflicting_services`
     firewall_disable_conflicting_services: true
 ```
 
+List of known conflicting services:
+- iptables
+- nftables
+- ufw
+
+Please submit a GitHub issue at the linux-system-roles/firewall there are services missing or
+add it locally to `vars/main.yml`.
 
 ## firewall
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ firewall
 ![CI Testing](https://github.com/linux-system-roles/firewall/workflows/tox/badge.svg)
 
 This role configures the firewall on machines that are using firewalld.
+If firewalld is not in use, the role will install (if not already installed),
+unmask, and enable firewalld.
+
+The role can also attempt to disable known conflicting services.
+The list of known conflicting services can be found in `vars/main.yml`,
+please sumbit an issue if there are any unaccounted-for services.
 
 For the configuration the role uses the firewalld client interface
 which is available in RHEL-7 and later.
@@ -195,6 +201,21 @@ permanent change was made to each setting:
 
 Variables
 ---------
+## firewall_disable_conflicting_services
+
+By default, the firewall role does not attempt to disable conflicting services such as `nftables.service` due to the
+overhead associated with enumerating the services when disabling services is potentially unecessary.
+To enable this feature, set the variable `firewall_disable_conflicting_services` to `true`:
+
+```yaml
+- name: Enable firewalld, disable conflicting services
+  include_role: linux-system-roles.firewall
+  vars:
+    firewall_disable_conflicting_services: true
+```
+
+
+## firewall
 
 The firewall role uses the variable `firewall` to specify the parameters.  This variable is a `list` of `dict` values.  Each `dict` value is comprised of one or more keys listed below. These are the variables that can be passed to the role:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 firewall: []
+firewall_disable_conflicting_services: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,26 +12,13 @@
     state: stopped
     enabled: false
   loop: "{{ __firewall_conflicting_services }}"
+  vars:
+    __service_name: "{{ (ansible_facts.service_mgr == 'systemd') |
+      ternary(item ~ '.service', item) }}"
   when:
     - firewall_disable_conflicting_services | bool
-    - (
-        ansible_facts.service_mgr == "systemd" and
-        item + ".service" | string in ansible_facts.services
-      )
-        or
-      (
-        ansible_facts.service_mgr != "systemd" and
-        item | string in ansible_facts.services
-      )
-    - (
-        ansible_facts.service_mgr == "systemd" and
-        ansible_facts.services[item + ".service"]["status"] == "enabled"
-      )
-        or
-      (
-        ansible_facts.service_mgr != "systemd" and
-        ansible_facts.services[item]["status"] == "enabled"
-      )
+    - __service_name | string in ansible_facts.services
+    - ansible_facts.services[__service_name]["status"] == "enabled"
 
 - name: Unmask firewalld service
   systemd:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,43 @@
 - name: Setup firewalld
   include_tasks: firewalld.yml
 
+- name: Collect service facts
+  service_facts:
+  when: firewall_disable_conflicting_services | bool
+
+- name: Attempt to stop and disable conflicting services
+  service:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+  loop: "{{ __firewall_conflicting_services }}"
+  when:
+    - firewall_disable_conflicting_services | bool
+    - (
+        ansible_facts.service_mgr == "systemd" and
+        item + ".service" | string in ansible_facts.services
+      )
+        or
+      (
+        ansible_facts.service_mgr != "systemd" and
+        item | string in ansible_facts.services
+      )
+    - (
+        ansible_facts.service_mgr == "systemd" and
+        ansible_facts.services[item + ".service"]["status"] == "enabled"
+      )
+        or
+      (
+        ansible_facts.service_mgr != "systemd" and
+        ansible_facts.services[item]["status"] == "enabled"
+      )
+
+- name: Unmask firewalld service
+  systemd:
+    name: "{{ __firewall_service }}"
+    masked: false
+  when: ansible_facts.service_mgr == "systemd"
+
 - name: Enable and start firewalld service
   service:
     name: "{{ __firewall_service }}"

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -16,12 +16,17 @@
       include_role:
         name: linux-system-roles.firewall
 
+    - name: Install conflicting service
+      package:
+        name: nftables
+        state: present
+
     - name: Enable conflicting service
       service:
         name: nftables
         enabled: true
 
-    - name: Attempt to run role with default parameters (3)
+    - name: Attempt to run role, disabling conflicting services
       include_role:
         name: linux-system-roles.firewall
       vars:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,5 +2,35 @@
 - name: Ensure that the roles runs with default parameters
   hosts: all
   gather_facts: false
-  roles:
-    - linux-system-roles.firewall
+  tasks:
+    - name: Attempt to run role with default parameters (1)
+      include_role:
+        name: linux-system-roles.firewall
+
+    - name: Mask firewalld
+      systemd:
+        name: firewalld
+        masked: true
+
+    - name: Attempt to run role with default parameters (2)
+      include_role:
+        name: linux-system-roles.firewall
+
+    - name: Enable conflicting service
+      service:
+        name: nftables
+        enabled: true
+
+    - name: Attempt to run role with default parameters (3)
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall_disable_conflicting_services: true
+
+    - name: Check that conflicting service is disabled
+      service:
+        name: nftables
+        enabled: false
+      check_mode: true
+      register: result
+      failed_when: result.changed

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -2,40 +2,5 @@
 - name: Ensure that the roles runs with default parameters
   hosts: all
   gather_facts: false
-  tasks:
-    - name: Attempt to run role with default parameters (1)
-      include_role:
-        name: linux-system-roles.firewall
-
-    - name: Mask firewalld
-      systemd:
-        name: firewalld
-        masked: true
-
-    - name: Attempt to run role with default parameters (2)
-      include_role:
-        name: linux-system-roles.firewall
-
-    - name: Install conflicting service
-      package:
-        name: nftables
-        state: present
-
-    - name: Enable conflicting service
-      service:
-        name: nftables
-        enabled: true
-
-    - name: Attempt to run role, disabling conflicting services
-      include_role:
-        name: linux-system-roles.firewall
-      vars:
-        firewall_disable_conflicting_services: true
-
-    - name: Check that conflicting service is disabled
-      service:
-        name: nftables
-        enabled: false
-      check_mode: true
-      register: result
-      failed_when: result.changed
+  roles:
+    - linux-system-roles.firewall

--- a/tests/tests_startup_conflicts.yml
+++ b/tests/tests_startup_conflicts.yml
@@ -1,0 +1,41 @@
+---
+- name: Ensure role handles startup issues
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Attempt to run role with default parameters (1)
+      include_role:
+        name: linux-system-roles.firewall
+
+    - name: Mask firewalld
+      systemd:
+        name: firewalld
+        masked: true
+
+    - name: Attempt to run role with default parameters (2)
+      include_role:
+        name: linux-system-roles.firewall
+
+    - name: Install conflicting service
+      package:
+        name: nftables
+        state: present
+
+    - name: Enable conflicting service
+      service:
+        name: nftables
+        enabled: true
+
+    - name: Attempt to run role, disabling conflicting services
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall_disable_conflicting_services: true
+
+    - name: Check that conflicting service is disabled
+      service:
+        name: nftables
+        enabled: false
+      check_mode: true
+      register: result
+      failed_when: result.changed

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,7 +6,13 @@ __firewall_firewalld_conf: "{{ __firewall_firewalld_dir }}/firewalld.conf"
 __firewall_required_facts:
   - python_interpreter
   - python_version
+  - service_mgr
 
 __firewall_packages_base: [firewalld]
 
 __firewall_service: firewalld
+
+__firewall_conflicting_services:
+  - nftables
+  - iptables
+  - ufw


### PR DESCRIPTION
Enhancement:
Role will now always attempt to unmask on role execution

add variable 'firewall_disable_conflicting_services' to give the option of disabling of known conflicting services
- Set to false by default

Update README to document the following behavior of the system role:
- linux-system-roles.firewall will attempt to install, unmask, and enable firewalld
- linux-system-roles.firewall can attempt to disable directly conflicting services to firewalld
  - and that is enabled by setting the variable 'firewall_disable_conflicting_services' to true
  - list of conflicting services present in vars/main.yml
  
 test cases for these changes in tests/tests_default.yml

Reason:
role currently fails if firewalld was masked on run
conflicting services have the potential to cause errors on role run
- set to false by default due to runtime overhead associated with disabling conflicting services. An example of where this overhead may be a problem is our integration tests that have no need to use the feature.
- Reason for specific implementation - ansible.builtin.service module fails when run to manage services that are not installed on the system, causing errors. While ignoring errors is a potential solution, it seemed like an improper solution as it would not be able to differentiate between an installed service that failing to be stopped and disabled vs a disable that failed due to not being installed.

Result:
- role no longer fails if firewalld is masked
- users have the option to disable conflicting services (iptables.service, nftables.service, ufw.service respectively)

Issue Tracker Tickets (Jira or BZ if any):
- Addresses GitHub Issues: #103, #136