### PR TITLE
fix: facts being gathered unnecessarily

### DIFF
--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,9 +1,9 @@
 ---
 - name: Ensure ansible_facts used by role
   setup:
-    gather_subset: min
-  when: not ansible_facts.keys() | list |
-    intersect(__firewall_required_facts) == __firewall_required_facts
+    gather_subset: "{{ __firewall_required_facts_subsets }}"
+  when: __firewall_required_facts |
+    difference(ansible_facts.keys() | list) | length > 0
 
 - name: Install firewalld
   package:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,6 +8,12 @@ __firewall_required_facts:
   - python_version
   - service_mgr
 
+# the subsets of ansible_facts that need to be gathered in case any of the
+# facts in required_facts is missing; see the documentation of
+# the 'gather_subset' parameter of the 'setup' module
+__firewall_required_facts_subsets: "{{ ['!all', '!min'] +
+  __firewall_required_facts }}"
+
 __firewall_packages_base: [firewalld]
 
 __firewall_service: firewalld


### PR DESCRIPTION
Cause: The comparison of the present facts with the required facts is
being done on unsorted lists.

Consequence: The comparison may fail if the only difference is the
order.  Facts are gathered unnecessarily.

Fix: Use `difference` which works no matter what the order is.  Ensure
that the fact gathering subsets used are the absolute minimum required.

Result: The role gathers only the facts it requires, and does
not unnecessarily gather facts.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
