### PR TITLE
feat: add new arg firewalld_conf, subarg allow_zone_drifting

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ if support for their modification has been implemented.
 ```yaml
 firewall:
   - firewalld_conf:
-      allow_zone_drifting: no
+      allow_zone_drifting: false
     permanent: true
 ```
 
@@ -249,7 +249,7 @@ and no longer exists.
 ```yaml
 firewall:
   firewalld_conf:
-    allow_zone_drifting: yes
+    allow_zone_drifting: true
   permanent: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,30 @@ add it locally to `vars/main.yml`.
 
 The firewall role uses the variable `firewall` to specify the parameters.  This variable is a `list` of `dict` values.  Each `dict` value is comprised of one or more keys listed below. These are the variables that can be passed to the role:
 
+### firewalld_conf
+`firewalld_conf` can be used to modify directives in firewalld's configuration file (`/etc/firewalld/conf` by default)
+if support for their modification has been implemented.
+
+**`permanent: true` must always be set to run this option without error**
+
+```yaml
+firewall:
+  - firewalld_conf:
+      allow_zone_drifting: "no"
+    permanent: true
+```
+
+#### Supported Directives
+##### allow_zone_drifting
+
+Changes the AllowZoneDrifting directive, if the directive exists.
+
+Accepted values:
+- "yes"
+- "no"
+
+Quotations around "yes" and "no" are necessary, because ansible attempts to convert the argument into boolean values otherwise.
+
 ### set_default_zone
 
 The default zone is the zone that is used for everything that is not explicitly

--- a/README.md
+++ b/README.md
@@ -234,20 +234,24 @@ if support for their modification has been implemented.
 ```yaml
 firewall:
   - firewalld_conf:
-      allow_zone_drifting: "no"
+      allow_zone_drifting: no
     permanent: true
 ```
 
 #### Supported Directives
 ##### allow_zone_drifting
 
-Changes the AllowZoneDrifting directive, if the directive exists.
+Changes the AllowZoneDrifting directive.
 
-Accepted values:
-- "yes"
-- "no"
+This parameter will do nothing if AllowZoneDrifting has been deprecated
+and no longer exists.
 
-Quotations around "yes" and "no" are necessary, because ansible attempts to convert the argument into boolean values otherwise.
+```yaml
+firewall:
+  firewalld_conf:
+    allow_zone_drifting: yes
+  permanent: true
+```
 
 ### set_default_zone
 

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -43,7 +43,7 @@ options:
     description:
       Modify firewalld.conf directives
     suboptions:
-      name: allow_zone_drifting
+      allow_zone_drifting:
       description:
         Set AllowZoneDrifting directive if not deprecated
       required: false

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -651,6 +651,9 @@ def main():
             module.warn(
                 "AllowZoneDrifting is deprecated in this version of firewalld and no longer supported"
             )
+    else:
+        # CodeQL will produce an error without this line
+        allow_zone_drifting_deprecated = None
     service = module.params["service"]
     short = module.params["short"]
     description = module.params["description"]

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -541,7 +541,7 @@ def parse_forward_port(module, item):
     return (_port, _protocol, _to_port, _to_addr)
 
 
-def check_allow_zone_drifting(am, firewalld_conf):
+def check_allow_zone_drifting(firewalld_conf):
     if firewalld_conf["allow_zone_drifting"] is not None:
         if firewalld_conf["allow_zone_drifting"]:
             firewalld_conf["allow_zone_drifting"] = "yes"
@@ -551,8 +551,8 @@ def check_allow_zone_drifting(am, firewalld_conf):
 
 # Parse all suboptions of firewalld_conf into how they will be used by the role
 # Return True if all suboptions were emptied as a result
-def check_firewalld_conf(am, firewalld_conf):
-    check_allow_zone_drifting(am, firewalld_conf)
+def check_firewalld_conf(firewalld_conf):
+    check_allow_zone_drifting(firewalld_conf)
 
 
 def set_the_default_zone(fw, set_default_zone):
@@ -568,7 +568,7 @@ def main():
                 options=dict(
                     allow_zone_drifting=dict(required=False, type="bool", default=None),
                 ),
-                default=dict(),
+                default=None,
             ),
             service=dict(required=False, type="list", elements="str", default=[]),
             port=dict(required=False, type="list", elements="str", default=[]),
@@ -643,7 +643,7 @@ def main():
     # Argument parse
     firewalld_conf = module.params["firewalld_conf"]
     if firewalld_conf:
-        check_firewalld_conf(module, firewalld_conf)
+        check_firewalld_conf(firewalld_conf)
         allow_zone_drifting_deprecated = lsr_parse_version(
             FW_VERSION
         ) >= lsr_parse_version("1.0.0")

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -46,9 +46,8 @@ options:
       name: allow_zone_drifting
       description:
         Set AllowZoneDrifting directive if not deprecated
-      choices: [ "yes", "no" ]
       required: false
-      type: str
+      type: bool
     required: false
     type: dict
   service:
@@ -554,7 +553,7 @@ def main():
                 type="dict",
                 options=dict(
                     allow_zone_drifting=dict(
-                        required=False, type="str", choices=["yes", "no"], default=None
+                        required=False, type="bool", default=None
                     ),
                 ),
                 default=dict(),
@@ -631,6 +630,12 @@ def main():
 
     # Argument parse
     firewalld_conf = module.params["firewalld_conf"]
+    if firewalld_conf:
+        if firewalld_conf["allow_zone_drifting"] is not None:
+            if firewalld_conf["allow_zone_drifting"]:
+                firewalld_conf["allow_zone_drifting"] = "yes"
+            else:
+                firewalld_conf["allow_zone_drifting"] = "no"
     service = module.params["service"]
     short = module.params["short"]
     description = module.params["description"]

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -552,9 +552,7 @@ def main():
                 required=False,
                 type="dict",
                 options=dict(
-                    allow_zone_drifting=dict(
-                        required=False, type="bool", default=None
-                    ),
+                    allow_zone_drifting=dict(required=False, type="bool", default=None),
                 ),
                 default=dict(),
             ),

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -44,10 +44,10 @@ options:
       Modify firewalld.conf directives
     suboptions:
       allow_zone_drifting:
-      description:
-        Set AllowZoneDrifting directive if not deprecated
-      required: false
-      type: bool
+        description:
+          Set AllowZoneDrifting directive if not deprecated
+        required: false
+        type: bool
     required: false
     type: dict
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,6 +73,7 @@
       - key: detailed
         value: false
   firewall_lib:
+    firewalld_conf: "{{ item.firewalld_conf | default(omit) }}"
     zone: "{{ item.zone | default(omit) }}"
     set_default_zone: "{{ item.set_default_zone | default(omit) }}"
     service: "{{ item.service | default(omit) }}"

--- a/tests/tests_firewalld_conf.yml
+++ b/tests/tests_firewalld_conf.yml
@@ -1,0 +1,58 @@
+---
+- name: Test firewalld_conf options
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Initial run, reset, disable zone drifting
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall:
+          previous: replaced
+          firewalld_conf:
+            allow_zone_drifting: "no"
+          permanent: true
+
+    - name: Assert AllowZoneDrifting is disabled
+      shell:
+        cmd: >-
+          set -o pipefail;
+          (grep AllowZoneDrifting /etc/firewalld/firewalld.conf
+          || echo "AllowZoneDrifting=no") | tail -1
+      register: result
+      changed_when: false
+      failed_when: result.stdout_lines[0] != "AllowZoneDrifting=no"
+
+    - name: Start with clean configuration
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall:
+          previous: replaced
+          firewalld_conf:
+            allow_zone_drifting: "yes"
+          permanent: true
+
+    - name: Get firewalld version
+      command: firewall-cmd --version
+      register: result
+      changed_when: false
+
+    - name: Check if AllowZoneDrifting deprecated (>= v1.0.0)
+      set_fact:
+        allow_zone_drifting_deprecated: >-
+          "{{ result.stdout[0] | int > 0 | bool }}"
+
+    - name: Assert AllowZoneDrifting is enabled if possible
+      vars:
+        expected_result: >-
+          "{{ allow_zone_drifting_deprecated | ternary('no', 'yes') | quote }}"
+      shell:
+        cmd: >-
+          set -o pipefail;
+          (grep AllowZoneDrifting /etc/firewalld/firewalld.conf
+          || echo "AllowZoneDrifting=no") | tail -1
+      register: result
+      changed_when: false
+      failed_when: >-
+        result.stdout_lines[0] != "AllowZoneDrifting=" + expected_result

--- a/tests/tests_firewalld_conf.yml
+++ b/tests/tests_firewalld_conf.yml
@@ -30,28 +30,17 @@
           permanent: true
 
     - name: Check if AllowZoneDrifting is disabled if possible
-      shell:
-        cmd: >-
-          set -o pipefail;
-          grep AllowZoneDrifting /etc/firewalld/firewalld.conf | tail -1
+      command: grep -Fx AllowZoneDrifting=no /etc/firewalld/firewalld.conf
       register: result
       changed_when: false
       failed_when: result.rc == 2
 
-    - name: Fail if AllowZoneDrifting disabled if not deprecated
+    - name: Fail if AllowZoneDrifting disabled and not deprecated
       fail:
         msg: "AllowZoneDrifting is enabled when it should be disabled"
       when:
-        - allow_zone_drifting_not_deprecated
-        - result.rc == 0
-        - result.stdout != "AllowZoneDrifting=no"
-
-    - name: Fail if AllowZoneDrifting not found and not deprecated
-      fail:
-        msg: "AllowZoneDrifting directive not found in firewalld.conf"
-      when:
-        - allow_zone_drifting_not_deprecated
-        - result.rc != 0
+        - allow_zone_drifting_not_deprecated | bool
+        - result.rc == 1
 
     - name: Try to enable zone drifting
       include_role:
@@ -63,10 +52,7 @@
           permanent: true
 
     - name: Check if AllowZoneDrifting is enabled if possible
-      shell:
-        cmd: >-
-          set -o pipefail;
-          grep AllowZoneDrifting /etc/firewalld/firewalld.conf | tail -1
+      command: grep -Fx AllowZoneDrifting=yes /etc/firewalld/firewalld.conf
       register: result
       changed_when: false
       failed_when: result.rc == 2
@@ -76,12 +62,4 @@
         msg: "AllowZoneDrifting is disabled when it should be enabled"
       when:
         - allow_zone_drifting_not_deprecated | bool
-        - result.rc == 0
-        - result.stdout != "AllowZoneDrifting=yes"
-
-    - name: Fail if AllowZoneDrifting not found and not deprecated
-      fail:
-        msg: "AllowZoneDrifting directive not found in firewalld.conf"
-      when:
-        - allow_zone_drifting_not_deprecated | bool
-        - result.rc != 0
+        - result.rc == 1

--- a/tests/tests_firewalld_conf.yml
+++ b/tests/tests_firewalld_conf.yml
@@ -83,5 +83,5 @@
       fail:
         msg: "AllowZoneDrifting directive not found in firewalld.conf"
       when:
-        - allow_zone_drifting_not_deprecated
+        - allow_zone_drifting_not_deprecated | bool
         - result.rc != 0

--- a/tests/tests_firewalld_conf.yml
+++ b/tests/tests_firewalld_conf.yml
@@ -75,7 +75,7 @@
       fail:
         msg: "AllowZoneDrifting is disabled when it should be enabled"
       when:
-        - allow_zone_drifting_not_deprecated
+        - allow_zone_drifting_not_deprecated | bool
         - result.rc == 0
         - result.stdout != "AllowZoneDrifting=yes"
 

--- a/tests/tests_firewalld_conf.yml
+++ b/tests/tests_firewalld_conf.yml
@@ -25,12 +25,44 @@
         name: linux-system-roles.firewall
       vars:
         firewall:
-          previous: replaced
           firewalld_conf:
-            allow_zone_drifting: no
+            allow_zone_drifting: false
           permanent: true
 
     - name: Check if AllowZoneDrifting is disabled if possible
+      shell:
+        cmd: >-
+          set -o pipefail;
+          grep AllowZoneDrifting /etc/firewalld/firewalld.conf | tail -1
+      register: result
+      changed_when: false
+      failed_when: result.rc == 2
+
+    - name: Fail if AllowZoneDrifting disabled if not deprecated
+      fail:
+        msg: "AllowZoneDrifting is enabled when it should be disabled"
+      when:
+        - allow_zone_drifting_not_deprecated
+        - result.rc == 0
+        - result.stdout != "AllowZoneDrifting=no"
+
+    - name: Fail if AllowZoneDrifting not found and not deprecated
+      fail:
+        msg: "AllowZoneDrifting directive not found in firewalld.conf"
+      when:
+        - allow_zone_drifting_not_deprecated
+        - result.rc != 0
+
+    - name: Try to enable zone drifting
+      include_role:
+        name: linux-system-roles.firewall
+      vars:
+        firewall:
+          firewalld_conf:
+            allow_zone_drifting: true
+          permanent: true
+
+    - name: Check if AllowZoneDrifting is enabled if possible
       shell:
         cmd: >-
           set -o pipefail;
@@ -45,7 +77,7 @@
       when:
         - allow_zone_drifting_not_deprecated
         - result.rc == 0
-        - result.stdout != "AllowZoneDrifting=no"
+        - result.stdout != "AllowZoneDrifting=yes"
 
     - name: Fail if AllowZoneDrifting not found and not deprecated
       fail:

--- a/tests/tests_firewalld_conf.yml
+++ b/tests/tests_firewalld_conf.yml
@@ -3,56 +3,53 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Initial run, reset, disable zone drifting
+    - name: Start with a clean configuration
       include_role:
         name: linux-system-roles.firewall
       vars:
         firewall:
           previous: replaced
-          firewalld_conf:
-            allow_zone_drifting: "no"
-          permanent: true
 
-    - name: Assert AllowZoneDrifting is disabled
-      shell:
-        cmd: >-
-          set -o pipefail;
-          (grep AllowZoneDrifting /etc/firewalld/firewalld.conf
-          || echo "AllowZoneDrifting=no") | tail -1
+    - name: Determine if AllowZoneDrifting is deprecated
+      command: grep AllowZoneDrifting /etc/firewalld/firewalld.conf
       register: result
       changed_when: false
-      failed_when: result.stdout_lines[0] != "AllowZoneDrifting=no"
+      failed_when: result.rc == 2
 
-    - name: Start with clean configuration
-      include_role:
-        name: linux-system-roles.firewall
-      vars:
-        firewall:
-          previous: replaced
-          firewalld_conf:
-            allow_zone_drifting: "yes"
-          permanent: true
-
-    - name: Get firewalld version
-      command: firewall-cmd --version
-      register: result
-      changed_when: false
-
-    - name: Check if AllowZoneDrifting deprecated (>= v1.0.0)
+    - name: Set fact allow_zone_drifting_not_deprecated
       set_fact:
-        allow_zone_drifting_deprecated: >-
-          "{{ result.stdout[0] | int > 0 | bool }}"
+        allow_zone_drifting_not_deprecated: "{{ result.rc == 0 }}"
 
-    - name: Assert AllowZoneDrifting is enabled if possible
+    - name: Try to disable zone drifting
+      include_role:
+        name: linux-system-roles.firewall
       vars:
-        expected_result: >-
-          "{{ allow_zone_drifting_deprecated | ternary('no', 'yes') | quote }}"
+        firewall:
+          previous: replaced
+          firewalld_conf:
+            allow_zone_drifting: no
+          permanent: true
+
+    - name: Check if AllowZoneDrifting is disabled if possible
       shell:
         cmd: >-
           set -o pipefail;
-          (grep AllowZoneDrifting /etc/firewalld/firewalld.conf
-          || echo "AllowZoneDrifting=no") | tail -1
+          grep AllowZoneDrifting /etc/firewalld/firewalld.conf | tail -1
       register: result
       changed_when: false
-      failed_when: >-
-        result.stdout_lines[0] != "AllowZoneDrifting=" + expected_result
+      failed_when: result.rc == 2
+
+    - name: Fail if AllowZoneDrifting disabled if not deprecated
+      fail:
+        msg: "AllowZoneDrifting is disabled when it should be enabled"
+      when:
+        - allow_zone_drifting_not_deprecated
+        - result.rc == 0
+        - result.stdout != "AllowZoneDrifting=no"
+
+    - name: Fail if AllowZoneDrifting not found and not deprecated
+      fail:
+        msg: "AllowZoneDrifting directive not found in firewalld.conf"
+      when:
+        - allow_zone_drifting_not_deprecated
+        - result.rc != 0

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -681,6 +681,20 @@ class FirewallLibMain(unittest.TestCase):
         )
 
     @patch("firewall_lib.HAS_FIREWALLD", True)
+    @patch("firewall_lib.FW_VERSION", "1.0.0", create=True)
+    def test_allow_zone_drifting_deprecated(self, am_class):
+        am = am_class.return_value
+        am.params = {
+            "firewalld_conf": {"allow_zone_drifting": False},
+            "permanent": True,
+        }
+        firewall_lib.main()
+        am.warn.assert_called_with(
+            "AllowZoneDrifting is deprecated in this version of firewalld, unsetting parameter"
+        )
+        am.exit_json.assert_called_with(changed=False, __firewall_changed=False)
+
+    @patch("firewall_lib.HAS_FIREWALLD", True)
     @patch("firewall_lib.FW_VERSION", "0.9.0", create=True)
     @patch("firewall_lib.FirewallClient", create=True)
     def test_allow_zone_zone_drifting_proper_usage(self, firewall_class, am_class):

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -682,15 +682,16 @@ class FirewallLibMain(unittest.TestCase):
 
     @patch("firewall_lib.HAS_FIREWALLD", True)
     @patch("firewall_lib.FW_VERSION", "1.0.0", create=True)
-    def test_allow_zone_drifting_deprecated(self, am_class):
+    @patch("firewall_lib.FirewallClient", create=True)
+    def test_allow_zone_drifting_deprecated(self, firewall_class, am_class):
         am = am_class.return_value
         am.params = {
-            "firewalld_conf": {"allow_zone_drifting": False},
+            "firewalld_conf": {"allow_zone_drifting": True},
             "permanent": True,
         }
         firewall_lib.main()
         am.warn.assert_called_with(
-            "AllowZoneDrifting is deprecated in this version of firewalld, unsetting parameter"
+            "AllowZoneDrifting is deprecated in this version of firewalld and no longer supported"
         )
         am.exit_json.assert_called_with(changed=False, __firewall_changed=False)
 

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -409,7 +409,8 @@ class FirewallLibMain(unittest.TestCase):
         am_class.return_value.fail_json.assert_called_with(
             msg="One of service, port, source_port, forward_port, "
             "masquerade, rich_rule, source, interface, icmp_block, "
-            "icmp_block_inversion, target, zone or set_default_zone needs to be set"
+            "icmp_block_inversion, target, zone, set_default_zone or firewalld_conf "
+            "needs to be set"
         )
 
     @patch("firewall_lib.HAS_FIREWALLD", True)
@@ -667,6 +668,28 @@ class FirewallLibMain(unittest.TestCase):
             "Service does not exist - http-alt."
             + " Ensure that you define the service in the playbook before running it in diff mode"
         )
+
+    @patch("firewall_lib.HAS_FIREWALLD", True)
+    @patch("firewall_lib.FW_VERSION", "0.9.0", create=True)
+    def test_allow_zone_drifting_runtime(self, am_class):
+        am = am_class.return_value
+        am.params = {"firewalld_conf": {"allow_zone_drifting": "no"}}
+        with self.assertRaises(MockException):
+            firewall_lib.main()
+        am.fail_json.assert_called_with(
+            msg="firewalld_conf can only be used with permanent"
+        )
+
+    @patch("firewall_lib.HAS_FIREWALLD", True)
+    @patch("firewall_lib.FW_VERSION", "0.9.0", create=True)
+    @patch("firewall_lib.FirewallClient", create=True)
+    def test_allow_zone_zone_drifting_proper_usage(self, firewall_class, am_class):
+        am = am_class.return_value
+        am.params = {"firewalld_conf": dict(), "permanent": True}
+
+        for option in ["yes", "no"]:
+            am.params["firewalld_conf"]["allow_zone_drifting"] = option
+            firewall_lib.main()
 
 
 @pytest.mark.parametrize("method,state,input,expected", TEST_PARAMS)

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -673,7 +673,7 @@ class FirewallLibMain(unittest.TestCase):
     @patch("firewall_lib.FW_VERSION", "0.9.0", create=True)
     def test_allow_zone_drifting_runtime(self, am_class):
         am = am_class.return_value
-        am.params = {"firewalld_conf": {"allow_zone_drifting": "no"}}
+        am.params = {"firewalld_conf": {"allow_zone_drifting": False}}
         with self.assertRaises(MockException):
             firewall_lib.main()
         am.fail_json.assert_called_with(
@@ -687,7 +687,7 @@ class FirewallLibMain(unittest.TestCase):
         am = am_class.return_value
         am.params = {"firewalld_conf": dict(), "permanent": True}
 
-        for option in ["yes", "no"]:
+        for option in [True, False]:
             am.params["firewalld_conf"]["allow_zone_drifting"] = option
             firewall_lib.main()
 


### PR DESCRIPTION
Enhancement:
firewall varable option firewalld_conf added to support modifying supported firewalld_conf arguments
- Sub-argument allow_zone_drifting modifies AllowZoneDrifting if possible via dbus
  - This should be supported in EL7+ due to backporting
- Associated Documentation added
- Unit tests for feature added to tests/unit/test_firewall_lib.py
- Integration test for feature in tests/tests_firewalld_conf.yml

Reason:
Many EL releases for firewalld set `AllowZoneDrifting=yes` as the default. This feature allows those who do not want this insecure feature set to disable the feature using the role.

Result:
AllowZoneDrifting can be changed to whatever the role user wants to change it to, provided it is not deprecated.

Will fail if the system is using a version of firewalld where `AllowZoneDrifting` has not been implemented. This should not be an issue on EL7 since the feature seems to have been backported to those systems, and should not be an issue on systems where the feature is removed because the dbus method for modifying the directive is still present (although it does not do anything).

Issue Tracker Tickets (Jira or BZ if any):
- Addresses GitHub Issue #127
