### PR TITLE
fix: error when running with check mode and previous: replaced

### DIFF
--- a/files/get_files_checksums.sh
+++ b/files/get_files_checksums.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 python_cmd="$1"
 firewall_conf_root="${2:-/etc/firewalld}"
 remove="${3:-false}"
+package="${4:-}"
+firewall_usr_lib="${5:-}"
 
 listfile=$(mktemp)
 firewallconf=$(mktemp)
@@ -13,24 +15,44 @@ trap "rm -f $listfile $firewallconf" EXIT
 
 find "$firewall_conf_root" -name \*.xml | while read -r file; do
     cksum=$(xmllint --c14n "$file" | sha256sum | awk '{print $1}')
-    echo "$cksum" "$file"
+    if [ -n "$firewall_usr_lib" ]; then
+        usr_lib_file="${firewall_usr_lib}${file##"$firewall_conf_root"}"
+        if [ -f "$usr_lib_file" ]; then
+            cksum_usr_lib=$(xmllint --c14n "$usr_lib_file" | sha256sum | awk '{print $1}')
+            if [ "$cksum" != "$cksum_usr_lib" ]; then
+                echo "$cksum" "$file"
+            fi
+        else
+            echo "$cksum" "$file"
+        fi
+    else
+        echo "$cksum" "$file"
+    fi
 done > "$listfile"
 
-if [ -f "$firewall_conf_root/firewalld.conf" ]; then
-    cp "$firewall_conf_root/firewalld.conf" "$firewallconf"
-    "$python_cmd" -c 'import os, sys
+orig_conf="$firewall_conf_root/firewalld.conf"
+remove_firewall_conf=true
+if [ -f "$orig_conf" ]; then
+    if [ -z "$package" ] || rpm -V "$package" | grep -q "c ${orig_conf}$"; then
+        cp "$orig_conf" "$firewallconf"
+        "$python_cmd" -c 'import os, sys
 from firewall.core.io.firewalld_conf import firewalld_conf
 fc = firewalld_conf(sys.argv[1])
 fc.read(); os.unlink(sys.argv[1])
 fc.write()
 ' "$firewallconf"
-    cksum=$(sha256sum "$firewallconf" | awk '{print $1}')
-    echo "$cksum" "$firewall_conf_root/firewalld.conf" >> "$listfile"
+        cksum=$(sha256sum "$firewallconf" | awk '{print $1}')
+        echo "$cksum" "$orig_conf" >> "$listfile"
+    else
+        remove_firewall_conf=false
+    fi
 fi
 
 if [ "${remove:-false}" = true ]; then
     find "$firewall_conf_root" -name \*.xml -exec rm -f {} \;
-    rm -f "$firewall_conf_root/firewalld.conf"
+    if [ "$remove_firewall_conf" = true ]; then
+        rm -f "$orig_conf"
+    fi
     if [ -s "$listfile" ] ; then
         firewall-cmd --reload > /dev/null
     fi

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,15 +40,27 @@
       list | length > 0 }}"
     __firewall_python_cmd: "{{ ansible_python_interpreter |
       d(discovered_interpreter_python) }}"
+    __firewall_report_changed: true
 
-- name: Get config files, checksums before and remove
-  script:
-    cmd: >
-      files/get_files_checksums.sh {{ __firewall_python_cmd | quote }}
-      {{ __firewall_firewalld_dir | quote }} true
-  register: __firewall_config_files_before
-  changed_when: false
+- name: Handle previous replaced
   when: __firewall_previous_replaced | bool
+  block:
+    - name: Get config files, checksums before and remove
+      script:
+        cmd: >
+          files/get_files_checksums.sh {{ __firewall_python_cmd | quote }}
+          {{ __firewall_firewalld_dir | quote }}
+          {{ ansible_check_mode | ternary('false', 'true') }}
+          {{ __firewall_package_with_conf | quote }}
+          {{ __firewall_usr_lib_dir | quote }}
+      register: __firewall_config_files_before
+      changed_when: false
+      check_mode: false
+
+    - name: Tell firewall module it is able to report changed
+      set_fact:
+        __firewall_report_changed: "{{
+          __firewall_config_files_before.stdout == '' }}"
 
 # Explanation of loop - `firewall` is a list of dict.  We want
 # to remove any key: value matching previous: replaced from every
@@ -96,7 +108,7 @@
     permanent: "{{ item.permanent | default(True) }}"
     runtime: "{{ item.runtime | default(True) }}"
     state: "{{ item.state | default(omit) }}"
-    __report_changed: "{{ not __firewall_previous_replaced }}"
+    __report_changed: "{{ __firewall_report_changed }}"
   loop: "{{ firewall is mapping | ternary([firewall], firewall) |
     map('dict2items') | map('difference', __previous) |
     map('difference', __detailed) | select |
@@ -141,13 +153,17 @@
         firewall_config: "{{ __firewalld_facts.firewall_config }}"
 
 - name: Check config files after removal
-  when: __firewall_previous_replaced | bool
+  when:
+    - __firewall_previous_replaced | bool
+    - not ansible_check_mode
   block:
     - name: Get config files, checksums after
       script:
         cmd: >
           files/get_files_checksums.sh {{ __firewall_python_cmd | quote }}
-          {{ __firewall_firewalld_dir | quote }}
+          {{ __firewall_firewalld_dir | quote }} false
+          {{ __firewall_package_with_conf | quote }}
+          {{ __firewall_usr_lib_dir | quote }}
       register: __firewall_config_files_after
       changed_when: false
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 __firewall_firewalld_dir: /etc/firewalld
 __firewall_firewalld_conf: "{{ __firewall_firewalld_dir }}/firewalld.conf"
+__firewall_usr_lib_dir: /usr/lib/firewalld
 
 # ansible_facts required by the role
 __firewall_required_facts:
@@ -14,6 +15,9 @@ __firewall_required_facts_subsets: "{{ ['!all', '!min'] +
   __firewall_required_facts }}"
 
 __firewall_packages_base: [firewalld]
+
+# This is the package providing the default /etc/firewall/firewalld.conf
+__firewall_package_with_conf: firewalld
 
 __firewall_service: firewalld
 


### PR DESCRIPTION
Cause: The role was not checking to see if any files would be
changed when using `previous: replaced` in check mode.  The variables
that should have been set were not set in check mode.

Consequence: The role would give an error about undefined variables.

Fix: A new check has been added for check mode, to see if any files
would be changed by `previous: replaced`.  The check for
`firewalld.conf` looks at the rpm database to determine if the file
has been changed from the version shipped in the package.  If files
would not be changed by using `previous: replaced`, then the role
will also now correctly report if any settings would be changed.

Result: The role works in check mode when using `previous: replaced`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
