### PR TITLE
test: tests_ansible zone cleanup; check for default zone

### DIFF
--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -8,6 +8,11 @@
       import_role:
         name: linux-system-roles.firewall
 
+    - name: Get default zone
+      command: firewall-cmd --get-default-zone
+      register: __default_zone
+      changed_when: false
+
     - name: Test firewalld posix compatibility
       block:
 
@@ -645,6 +650,12 @@
               command: firewall-cmd --permanent --load-zone-defaults=public
               register: result
               failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
+              changed_when: false
+
+            - name: Reset default zone
+              command: >-
+                firewall-cmd
+                --set-default-zone={{ __default_zone.stdout | quote }}
               changed_when: false
 
             - name: Reload firewalld

--- a/tests/tests_firewall_fact.yml
+++ b/tests/tests_firewall_fact.yml
@@ -12,6 +12,11 @@
             firewall:
               - previous: replaced
 
+        - name: Get default zone
+          command: firewall-cmd --get-default-zone
+          changed_when: false
+          register: __default_zone
+
         # Test base fact (no custom settings applied)
 
         - name: Get default ansible fact
@@ -36,10 +41,10 @@
           when: item | length == 0
           loop: "{{ firewall_config.default | dict2items }}"
 
-        - name: Fail if default zone is not public
+        - name: Fail if default zone is not correct
           fail:
-            msg: default zone should be public
-          when: firewall_config.default_zone != "public"
+            msg: default zone should be {{ __default_zone.stdout }}
+          when: firewall_config.default_zone != __default_zone.stdout
 
         - name: Save default ansible fact value
           set_fact:


### PR DESCRIPTION
In tests_ansible - save and restore default zone
In tests_firewall_fact - ensure default zone did
not change instead of hardcoded `public` zone

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
