### PR TITLE
fix: firewall_lib: make try_set_zone_of_interface idempotent

### DIFF
--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -195,6 +195,42 @@
           register: result
           failed_when: result.failed or result.changed
 
+        - name: Allow nm interface eth0 in permanent trusted zone
+          firewall_lib:
+            zone: trusted
+            interface: eth0
+            permanent: true
+            state: enabled
+          register: result
+          failed_when: result.failed or not result.changed
+
+        - name: Allow nm interface eth0 in permanent trusted zone, again
+          firewall_lib:
+            zone: trusted
+            interface: eth0
+            permanent: true
+            state: enabled
+          register: result
+          failed_when: result.failed or result.changed
+
+        - name: Disable nm interface eth0 in permanent trusted zone
+          firewall_lib:
+            zone: trusted
+            interface: eth0
+            permanent: true
+            state: disabled
+          register: result
+          failed_when: result.failed or not result.changed
+
+        - name: Disable nm interface eth0 in permanent trusted zone, again
+          firewall_lib:
+            zone: trusted
+            interface: eth0
+            permanent: true
+            state: disabled
+          register: result
+          failed_when: result.failed or result.changed
+
         - name: Allow interface eth2 in permanent trusted zone
           firewall_lib:
             zone: trusted


### PR DESCRIPTION
Enhancement:
Make try_set_zone_of_interface in library/firewall_lib.py return a second value, which denotes whether the interface's zone was changed.

Reason:
Network Manager interface assignment reported changed when no changes were present

Result:
The module now properly reports changes when assigning zones to interfaces handled by Network Manager.

Issue Tracker Tickets (Jira or BZ if any):
- Jira - RHEL-885
