### PR TITLE
tests: test_ping: fix compatability issues

### DIFF
--- a/tests/tests_reload_on_reset.yml
+++ b/tests/tests_reload_on_reset.yml
@@ -18,6 +18,8 @@
         cmd: files/test_ping.sh
         executable: /bin/bash
       register: test_results
+      environment:
+        TEST_DEBUG: "{{ lookup('env', 'TEST_DEBUG') }}"
 
     - name: Process test results
       vars:


### PR DESCRIPTION
Test script no longer fails if managed node does not support podman network create --interface name

Enhancement:
- Removed unnecessary imports from Containerfile generated by tests/files/test_ping.sh
- Removed usage of --interface-name from podman network create in test_ping.sh (and removed usage of podman network create in general, since that is also unnecessary for the purposes of the test)

Reason:
test fails on some platforms (RHEL 8.8, 9.2) due to podman not supporting `podman network create --interface-name` option

Result:
Tests pass on managed nodes with podman versions < v4.4

