### PR TITLE
fix: files: overwrite firewalld.conf on previous replaced

### DIFF
--- a/files/get_files_checksums.sh
+++ b/files/get_files_checksums.sh
@@ -30,10 +30,12 @@ find "$firewall_conf_root" -name \*.xml | while read -r file; do
     fi
 done > "$listfile"
 
+set +o pipefail
+
 orig_conf="$firewall_conf_root/firewalld.conf"
 remove_firewall_conf=true
 if [ -f "$orig_conf" ]; then
-    if [ -z "$package" ] || (rpm -V "$package" || true) | grep -q "c ${orig_conf}$"; then
+    if [ -z "$package" ] || rpm -V "$package" | grep -q "c ${orig_conf}$"; then
         cp "$orig_conf" "$firewallconf"
         "$python_cmd" -c 'import os, sys
 from firewall.core.io.firewalld_conf import firewalld_conf
@@ -47,6 +49,8 @@ fc.write()
         remove_firewall_conf=false
     fi
 fi
+
+set -o pipefail
 
 if [ "${remove:-false}" = true ]; then
     find "$firewall_conf_root" -name \*.xml -exec rm -f {} \;

--- a/tests/tests_purge_config.yml
+++ b/tests/tests_purge_config.yml
@@ -143,6 +143,27 @@
           fail:
             msg: The role reported changes
           when: firewall_lib_result.changed  # noqa no-handler
+
+        # test firewalld.conf deletion
+
+        - name: Change default zone (Change firewalld.conf)
+          include_role:
+            name: linux-system-roles.firewall
+          vars:
+            firewall:
+              - set_default_zone: internal
+
+        - name: Purge config
+          include_role:
+            name: linux-system-roles.firewall
+          vars:
+            firewall:
+              - previous: replaced
+
+        - name: Fail if /etc/firewalld/firewalld.conf no longer exists
+          command: test -f /etc/firewalld/firewalld.conf
+          changed_when: false
+
       always:
         - name: Cleanup
           tags:

--- a/tests/tests_purge_config.yml
+++ b/tests/tests_purge_config.yml
@@ -144,7 +144,7 @@
             msg: The role reported changes
           when: firewall_lib_result.changed  # noqa no-handler
 
-        # test firewalld.conf deletion
+        ### Test firewalld.conf reset
 
         - name: Change default zone (Change firewalld.conf)
           include_role:
@@ -152,6 +152,12 @@
           vars:
             firewall:
               - set_default_zone: internal
+
+        - name: Get stats for firewalld.conf
+          stat:
+            path: /etc/firewalld/firewalld.conf
+          register: __stat_before
+          failed_when: not __stat_before.stat.exists
 
         - name: Purge config
           include_role:
@@ -161,8 +167,33 @@
               - previous: replaced
 
         - name: Fail if /etc/firewalld/firewalld.conf no longer exists
-          command: test -f /etc/firewalld/firewalld.conf
-          changed_when: false
+          stat:
+            path: /etc/firewalld/firewalld.conf
+          register: __stat_after_a
+          failed_when: not __stat_after_a.stat.exists
+
+        - name: Assert that collected firewalld.conf checksums do not match
+          fail:
+            msg: firewalld.conf should have changed on reset
+          when: __stat_before.stat.checksum == __stat_after_a.stat.checksum
+
+        - name: Purge config (no changes made since last purge)
+          include_role:
+            name: linux-system-roles.firewall
+          vars:
+            firewall:
+              - previous: replaced
+
+        - name: Fail if /etc/firewalld/firewalld.conf no longer exists
+          stat:
+            path: /etc/firewalld/firewalld.conf
+          register: __stat_after_b
+          failed_when: not __stat_after_b.stat.exists
+
+        - name: Assert that collected firewalld.conf checksums match
+          fail:
+            msg: firewalld.conf should have changed on reset
+          when: __stat_after_a.stat.checksum != __stat_after_b.stat.checksum
 
       always:
         - name: Cleanup


### PR DESCRIPTION
on previous replaced, revert firewalld.conf to fallback configuration instead of deletion

Enhancement:
Replaces firewalld.conf on previous replaced instead of deleting when changed

Reason:
EL7+ firewalld releases appeared to support a fallback configuration in firewalld, which could be effectively used to override the previous configuration.

Result:
On reset, firewalld.conf is not deleted, and comments in the file are retained.

Addresses GitHub issue #164 
