### PR TITLE
refactor: improve support for ostree systems

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,4 +1,3 @@
 ---
 collections:
   - name: ansible.posix
-  - name: ansible.utils

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -5,25 +5,21 @@
   when: __firewall_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
-- name: Ensure correct package manager for ostree systems
-  vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-    ostree_booted_file: /run/ostree-booted
-  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+- name: Determine if system is ostree and set flag
+  when: not __firewall_is_ostree is defined
   block:
     - name: Check if system is ostree
       stat:
-        path: "{{ ostree_booted_file }}"
+        path: /run/ostree-booted
       register: __ostree_booted_stat
 
-    - name: Set package manager to use for ostree
-      ansible.utils.update_fact:
-        updates:
-          - path: ansible_facts.pkg_mgr
-            value: "{{ ostree_pkg_mgr }}"
-      when: __ostree_booted_stat.stat.exists
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __firewall_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
 - name: Install firewalld
   package:
     name: "{{ __firewall_packages_base }}"
     state: present
+    use: "{{ (__firewall_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"

--- a/tests/tests_reload_on_reset.yml
+++ b/tests/tests_reload_on_reset.yml
@@ -9,30 +9,24 @@
         - ansible_distribution in ['RedHat', 'CentOS']
         - ansible_distribution_major_version | int < 8
   tasks:
-    - name: Ensure correct package manager for ostree systems
-      vars:
-        ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-        ostree_booted_file: /run/ostree-booted
-      when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+    - name: Determine if system is ostree and set flag
+      when: not __firewall_is_ostree is defined
       block:
         - name: Check if system is ostree
           stat:
-            path: "{{ ostree_booted_file }}"
+            path: /run/ostree-booted
           register: __ostree_booted_stat
 
-        - name: Set package manager to use for ostree
+        - name: Set flag to indicate system is ostree
           set_fact:
-            ansible_facts: "{{ ansible_facts |
-              combine(new_facts, recursive=True) }}"
-          vars:
-            new_facts:
-              pkg_mgr: "{{ ostree_pkg_mgr }}"
-          when: __ostree_booted_stat.stat.exists
+            __firewall_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
     - name: Install podman
       package:
         name: podman
         state: present
+        use: "{{ (__firewall_is_ostree | d(false)) |
+                ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Run test
       script:

--- a/tests/tests_startup_conflicts.yml
+++ b/tests/tests_startup_conflicts.yml
@@ -16,30 +16,24 @@
       include_role:
         name: linux-system-roles.firewall
 
-    - name: Ensure correct package manager for ostree systems
-      vars:
-        ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-        ostree_booted_file: /run/ostree-booted
-      when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+    - name: Determine if system is ostree and set flag
+      when: not __firewall_is_ostree is defined
       block:
         - name: Check if system is ostree
           stat:
-            path: "{{ ostree_booted_file }}"
+            path: /run/ostree-booted
           register: __ostree_booted_stat
 
-        - name: Set package manager to use for ostree
+        - name: Set flag to indicate system is ostree
           set_fact:
-            ansible_facts: "{{ ansible_facts |
-              combine(new_facts, recursive=True) }}"
-          vars:
-            new_facts:
-              pkg_mgr: "{{ ostree_pkg_mgr }}"
-          when: __ostree_booted_stat.stat.exists
+            __firewall_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
     - name: Install conflicting service
       package:
         name: nftables
         state: present
+        use: "{{ (__firewall_is_ostree | d(false)) |
+                ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Enable conflicting service
       service:


### PR DESCRIPTION
The dependency on `ansible.utils.update_fact` is causing issue with
some users who now must install that collection in order to run
the role, even if they do not care about ostree.

The fix is to stop trying to set `ansible_facts.pkg_mgr`, and instead
force the use of the ostree package manager with the `package:` module
`use:` option.  The strategy is - on ostree systems, set the flag
`__$ROLENAME_is_ostree` if the system is an ostree system.  The flag
will either be undefined or `false` on non-ostree systems.
Then, change every invocation of the `package:` module like this:

```yaml
- name: Ensure required packages are present
  package:
    name: "{{ __$ROLENAME_packages }}"
    state: present
    use: "{{ (__$ROLENAME_is_ostree | d(false)) |
      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
```

This should ensure that the `use:` parameter is not used if the system
is non-ostree.  The goal is to make the ostree support as unobtrusive
as possible for non-ostree systems.
The user can also set `__$ROLENAME_is_ostree: true` in the inventory or play
if the user knows that ostree is being used and wants to skip the check.
Or, the user is concerned about the performance hit for ostree detection
on non-ostree systems, and sets `__$ROLENAME_is_ostree: false` to skip
the check.
The flag `__$ROLENAME_is_ostree` can also be used in the role or tests to
include or exclude tasks from being run on ostree systems.

This fix also improves error reporting in the `get_ostree_data.sh` script
when included roles cannot be found.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
