### PR TITLE
refactor: get_ostree_data.sh use env shebang - remove from .sanity*

### DIFF
--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -28,7 +28,7 @@ if [ "$pkgtype" = testing ]; then
 fi
 
 get_rolepath() {
-    local ostree_dir role rolesdir roles_parent_dir coll_path pth
+    local ostree_dir role rolesdir roles_parent_dir coll_path path
     ostree_dir="$1"
     role="$2"
     roles_parent_dir="$(dirname "$(dirname "$ostree_dir")")"
@@ -51,8 +51,8 @@ get_rolepath() {
         coll_path="${ANSIBLE_COLLECTIONS_PATHS:-}"
     fi
     if [ -n "${coll_path}" ]; then
-        for pth in ${coll_path//:/ }; do
-            for rolesdir in "$pth"/ansible_collections/*/*_system_roles/roles/"$role"/.ostree; do
+        for path in ${coll_path//:/ }; do
+            for rolesdir in "$path"/ansible_collections/*/*_system_roles/roles/"$role"/.ostree; do
                 if [ -d "$rolesdir" ]; then
                     echo "$rolesdir"
                     return 0

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -3,4 +3,3 @@ plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib.py validate-modules:missing-examples
 roles/firewall/files/get_files_checksums.sh shebang!skip
 tests/firewall/files/test_ping.sh shebang!skip
-roles/firewall/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -3,4 +3,3 @@ plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib.py validate-modules:missing-examples
 roles/firewall/files/get_files_checksums.sh shebang!skip
 tests/firewall/files/test_ping.sh shebang!skip
-roles/firewall/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -3,4 +3,3 @@ plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib.py validate-modules:missing-examples
 roles/firewall/files/get_files_checksums.sh shebang!skip
 tests/firewall/files/test_ping.sh shebang!skip
-roles/firewall/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -3,4 +3,3 @@ plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib.py validate-modules:missing-examples
 roles/firewall/files/get_files_checksums.sh shebang!skip
 tests/firewall/files/test_ping.sh shebang!skip
-roles/firewall/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -3,4 +3,3 @@ plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib.py validate-modules:missing-examples
 roles/firewall/files/get_files_checksums.sh shebang!skip
 tests/firewall/files/test_ping.sh shebang!skip
-roles/firewall/.ostree/get_ostree_data.sh shebang!skip


### PR DESCRIPTION
Use the `#!/usr/bin/env bash` shebang which is ansible-test friendly.
This means we can remove get_ostree_data.sh from the .sanity* files.
This also means we can remove the .sanity* files if we do not need
them otherwise.

Rename `pth` to `path` in honor of nscott

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
