### PR TITLE
ci: Use supported ansible-lint action; run ansible-lint against the collection

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -1,5 +1,2 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
-plugins/modules/firewall_lib.py validate-modules:missing-examples
-roles/firewall/files/get_files_checksums.sh shebang!skip
-tests/firewall/files/test_ping.sh shebang!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -1,5 +1,2 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
-plugins/modules/firewall_lib.py validate-modules:missing-examples
-roles/firewall/files/get_files_checksums.sh shebang!skip
-tests/firewall/files/test_ping.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,5 +1,2 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
-plugins/modules/firewall_lib.py validate-modules:missing-examples
-roles/firewall/files/get_files_checksums.sh shebang!skip
-tests/firewall/files/test_ping.sh shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -1,5 +1,2 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
-plugins/modules/firewall_lib.py validate-modules:missing-examples
-roles/firewall/files/get_files_checksums.sh shebang!skip
-tests/firewall/files/test_ping.sh shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,5 +1,2 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
-plugins/modules/firewall_lib.py validate-modules:missing-examples
-roles/firewall/files/get_files_checksums.sh shebang!skip
-tests/firewall/files/test_ping.sh shebang!skip

--- a/files/get_files_checksums.sh
+++ b/files/get_files_checksums.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -59,6 +59,7 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   port:
     description:
       List of ports or port range strings.
@@ -66,6 +67,7 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   source_port:
     description:
       List of source port or port range strings.
@@ -73,6 +75,7 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   forward_port:
     description:
       List of forward port strings or dicts,
@@ -82,6 +85,7 @@ options:
     aliases: ["port_forward"]
     required: false
     type: raw
+    default: []
   masquerade:
     description:
       The masquerade bool setting.
@@ -94,6 +98,7 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   source:
     description:
       List of source address, address range strings, or ipsets
@@ -104,12 +109,14 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   interface:
     description:
       List of interface name strings.
     required: false
     type: list
     elements: str
+    default: []
   interface_pci_id:
     description:
       List of inteface PCI device ID strings.
@@ -117,6 +124,7 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   icmp_block:
     description:
       List of ICMP type strings to block.
@@ -124,6 +132,7 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   icmp_block_inversion:
     description:
       ICMP block inversion bool setting.
@@ -178,6 +187,7 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   permanent:
     description:
       The permanent bool flag.
@@ -222,12 +232,14 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   helper_module:
     description:
       List of netfiler kernel helper module names
     required: false
     type: list
     elements: str
+    default: []
   destination:
     description:
       List of IPv4/IPv6 addresses with optional mask
@@ -237,12 +249,18 @@ options:
     required: false
     type: list
     elements: str
+    default: []
   __report_changed:
     description:
       If false, do not report changed true even if changed.
     required: false
     type: bool
     default: true
+"""
+
+EXAMPLES = """
+firewall:
+  - port: ['443/tcp', '443/udp']
 """
 
 from ansible.module_utils.basic import AnsibleModule

--- a/tests/files/test_ping.sh
+++ b/tests/files/test_ping.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author - Brennan Paciorek <bpaciore@redhat.com>
 # Description - Benchmark firewalld downtime while reloading and while restarting
 # by measuring how many packets are dropped while firewalld is restarting/reloading


### PR DESCRIPTION
The old ansible-community ansible-lint is deprecated.  There is a
new ansible-lint github action.  The new ansible-lint has several checks
related to ansible-test and the ignore files.  Many of our ignore settings
are not allowed any more and are required to be fixed or addressed in the
Ansible preferred way.

The module documentation must comply with the Ansible standards.

The result of this is that the .sanity files can be reduced to the
bare minimum which will greatly reduce the maintenance burden of
those files, make it easier to support newer versions of Ansible,
and make it easier to import the system roles collection into Galaxy
and Automation Hub.

The latest Ansible repo gating tests run ansible-lint against
the collection format instead of against individual roles.
We have to convert the role to collection format before running
ansible-test.

Role developers can run this locally using
`tox -e collection,ansible-lint-collection`
See https://github.com/linux-system-roles/tox-lsr/pull/125

Add `---` doc start to .markdownlint.yaml

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
