### PR TITLE
ci: Add conditional reboot for transactional update support

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,6 @@ It is also possible to combine several settings into blocks:
       - {service: tftp, state: enabled}
       - {port: '443/tcp', state: enabled}
       - {forward_port: 'eth0;445/tcp;;1.2.3.4', state: enabled}
-         state: enabled}
   roles:
     - linux-system-roles.firewall
 ```

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -29,4 +29,4 @@
   reboot:
   when:
     - firewall_package_result is changed
-    - ansible_distribution == 'ALP-Dolomite'
+    - ansible_distribution == "ALP-Dolomite"

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -22,4 +22,11 @@
     name: "{{ __firewall_packages_base }}"
     state: present
     use: "{{ (__firewall_is_ostree | d(false)) |
-             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+  register: firewall_package_result
+
+- name: Reboot transactional update systems
+  reboot:
+  when:
+    - firewall_package_result.changed
+    - ansible_distribution == 'ALP-Dolomite'

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -28,5 +28,5 @@
 - name: Reboot transactional update systems
   reboot:
   when:
-    - firewall_package_result.changed
+    - firewall_package_result is changed
     - ansible_distribution == 'ALP-Dolomite'


### PR DESCRIPTION
Enhancement: Add Conditional Reboot and README.md Syntax Fix

Reason: To support transactional update systems that require a reboot for changes to take effect and to correct a syntax error in the firewall configuration example in the readme.md.

Result: Ensures that changes on transactional systems are applied correctly if a new package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
