### PR TITLE
ci: Remove redundant reboot task

### DIFF
--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -23,10 +23,3 @@
     state: present
     use: "{{ (__firewall_is_ostree | d(false)) |
       ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  register: firewall_package_result
-
-- name: Reboot transactional update systems
-  reboot:
-  when:
-    - firewall_package_result is changed
-    - ansible_distribution == "ALP-Dolomite"


### PR DESCRIPTION
Enhancement: Redundant reboot task.

Reason: Removing unnecessary reboot task

Result: system will not reboot after package install

Issue Tracker Tickets (Jira or BZ if any):na
