### PR TITLE
feat: Handle reboot for transactional update systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,12 +771,12 @@ being reset and all new connections to the system are rejected.  Existing
 connections will be unaffected. Applying changes with this option in production
 might cause temporary service failures with new connections during the operation.
 
-### transactional_update_reboot_ok
+### firewall_transactional_update_reboot_ok
 
-This variable is used to handle reboots required by transactional updates. If a transactional update requires a reboot, the role will proceed with the reboot if transactional_update_reboot_ok is set to true. If set to false, the role will notify the user that a reboot is required, allowing for custom handling of the reboot requirement. If this variable is not set, the role will fail to ensure the reboot requirement is not overlooked.
+This variable is used to handle reboots required by transactional updates. If a transactional update requires a reboot, the role will proceed with the reboot if firewall_transactional_update_reboot_ok is set to true. If set to false, the role will notify the user that a reboot is required, allowing for custom handling of the reboot requirement. If this variable is not set, the role will fail to ensure the reboot requirement is not overlooked.
 
 ```yaml
-transactional_update_reboot_ok: true
+firewall_transactional_update_reboot_ok: true
 ```
 
 ## Examples of Options

--- a/README.md
+++ b/README.md
@@ -771,6 +771,19 @@ being reset and all new connections to the system are rejected.  Existing
 connections will be unaffected. Applying changes with this option in production
 might cause temporary service failures with new connections during the operation.
 
+### system_is_transactional
+
+This variable indicates whether the system uses transactional updates. It should be set to true if the system supports and is configured for transactional updates.
+
+### transactional_update_reboot_ok
+
+This variable is used to handle reboots required by transactional updates. If a transactional update requires a reboot, the role will proceed with the reboot if transactional_update_reboot_ok is set to true. If set to false, the role will notify the user that a reboot is required, allowing for custom handling of the reboot requirement. If this variable is not set, the role will fail to ensure the reboot requirement is not overlooked.
+
+```yaml
+system_is_transactional: true
+transactional_update_reboot_ok: true
+```
+
 ## Examples of Options
 
 By default, any changes will be applied immediately, and to the permanent settings. If you want the changes to apply immediately but not permanently, use `permanent: false`. Conversely, use `runtime: false`.

--- a/README.md
+++ b/README.md
@@ -771,16 +771,11 @@ being reset and all new connections to the system are rejected.  Existing
 connections will be unaffected. Applying changes with this option in production
 might cause temporary service failures with new connections during the operation.
 
-### system_is_transactional
-
-This variable indicates whether the system uses transactional updates. It should be set to true if the system supports and is configured for transactional updates.
-
 ### transactional_update_reboot_ok
 
 This variable is used to handle reboots required by transactional updates. If a transactional update requires a reboot, the role will proceed with the reboot if transactional_update_reboot_ok is set to true. If set to false, the role will notify the user that a reboot is required, allowing for custom handling of the reboot requirement. If this variable is not set, the role will fail to ensure the reboot requirement is not overlooked.
 
 ```yaml
-system_is_transactional: true
 transactional_update_reboot_ok: true
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 firewall: []
 firewall_disable_conflicting_services: false
-transactional_update_reboot_ok: null
+firewall_transactional_update_reboot_ok: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 firewall: []
 firewall_disable_conflicting_services: false
+transactional_update_reboot_ok: null

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -17,6 +17,18 @@
       set_fact:
         __firewall_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is transactional update and set flag
+  when: not __firewall_is_transactional is defined
+  block:
+    - name: Check if transactional-update exists in /sbin
+      stat:
+        path: /sbin/transactional-update
+      register: __transactional_update_stat
+
+    - name: Set flag if transactional-update exists
+      set_fact:
+        __firewall_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
+
 - name: Install firewalld
   package:
     name: "{{ __firewall_packages_base }}"
@@ -27,7 +39,7 @@
 
 - name: Handle reboot for transactional update systems
   when:
-    - system_is_transactional | d(false)
+    - __firewall_is_transactional | d(false)
     - firewall_package_result is changed
   block:
     - name: Notify user that reboot is needed to apply changes

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -49,13 +49,13 @@
 
     - name: Reboot transactional update systems
       reboot:
-        msg: "Rebooting the system to apply transactional update changes."
+        msg: Rebooting the system to apply transactional update changes.
       when:
-        - transactional_update_reboot_ok
+        - firewall_transactional_update_reboot_ok
 
     - name: Fail if reboot is needed and not set
       fail:
         msg: >
-          "Reboot is required but not allowed. Please set 'transactional_update_reboot_ok' to proceed."
+          Reboot is required but not allowed. Please set 'firewall_transactional_update_reboot_ok' to proceed.
       when:
-        - transactional_update_reboot_ok is none
+        - firewall_transactional_update_reboot_ok is none

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -47,15 +47,15 @@
         msg: >
           Reboot required to apply changes due to transactional updates.
 
+    - name: Reboot transactional update systems
+      reboot:
+        msg: "Rebooting the system to apply transactional update changes."
+      when:
+        - transactional_update_reboot_ok
+
     - name: Fail if reboot is needed and not set
       fail:
         msg: >
           "Reboot is required but not allowed. Please set 'transactional_update_reboot_ok' to proceed."
       when:
-        - transactional_update_reboot_ok is undefined
-
-    - name: Reboot transactional update systems
-      reboot:
-        msg: "Rebooting the system to apply transactional update changes."
-      when:
-        - transactional_update_reboot_ok | d(false)
+        - transactional_update_reboot_ok is none

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -51,7 +51,6 @@
       reboot:
         msg: Rebooting the system to apply transactional update changes.
       when: firewall_transactional_update_reboot_ok | bool
-        - firewall_transactional_update_reboot_ok
 
     - name: Fail if reboot is needed and not set
       fail:

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -50,7 +50,7 @@
     - name: Reboot transactional update systems
       reboot:
         msg: Rebooting the system to apply transactional update changes.
-      when:
+      when: firewall_transactional_update_reboot_ok | bool
         - firewall_transactional_update_reboot_ok
 
     - name: Fail if reboot is needed and not set

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -23,3 +23,27 @@
     state: present
     use: "{{ (__firewall_is_ostree | d(false)) |
       ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+  register: firewall_package_result
+
+- name: Handle reboot for transactional update systems
+  when:
+    - system_is_transactional | d(false)
+    - firewall_package_result is changed
+  block:
+    - name: Notify user that reboot is needed to apply changes
+      debug:
+        msg: >
+          Reboot required to apply changes due to transactional updates.
+
+    - name: Fail if reboot is needed and not set
+      fail:
+        msg: >
+          "Reboot is required but not allowed. Please set 'transactional_update_reboot_ok' to proceed."
+      when:
+        - transactional_update_reboot_ok is undefined
+
+    - name: Reboot transactional update systems
+      reboot:
+        msg: "Rebooting the system to apply transactional update changes."
+      when:
+        - transactional_update_reboot_ok | d(false)


### PR DESCRIPTION
Enhancement: - Added a block to handle reboots for transactional update systems on firewall package changes. Update README.

Reason: Ensure necessary reboots are managed, as changes on transactional update systems are applied in a separate snapshot and require a reboot to take effect.

Result: Manages system reboots for transactional update systems when package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
