### PR TITLE
fix: Prevent interface definitions overriding 'changed' value when other elements are changed

### DIFF
--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -1469,7 +1469,8 @@ def main():
             if permanent:
                 nm_used, if_changed = try_set_zone_of_interface(module, zone, item)
                 if nm_used:
-                    changed = if_changed
+                    if if_changed:
+                        changed = True
                 elif not fw_settings.queryInterface(item):
                     if not module.check_mode:
                         handle_interface_permanent(
@@ -1484,7 +1485,8 @@ def main():
             if permanent:
                 nm_used, if_changed = try_set_zone_of_interface(module, "", item)
                 if nm_used:
-                    changed = if_changed
+                    if if_changed:
+                        changed = True
                 elif fw_settings.queryInterface(item):
                     if not module.check_mode:
                         fw_settings.removeInterface(item)


### PR DESCRIPTION
Cause: The module was replacing the `changed` value with `False` when using `interface` and the interface exists.

Consequence: The role reported `changed: False` even when there were changes, and `forward_ports` were not being saved as permanent.

Fix: Ensure the `changed` value is not reset to `False` in this case.

Result: The role reports `changed: True` when there are changes, and `forward_ports` settings are persistent.

This fixes #234