### PR TITLE
ci: Avoid too large inline test logs in QEMU/KVM integration test

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -109,14 +109,24 @@ jobs:
               echo "$f"
           done < batch.report
 
-      - name: Show test logs on failure
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "logs-${{ matrix.scenario.image }}-${{ matrix.scenario.env }}"
+          path: tests/*.log
+          retention-days: 30
+
+      - name: Show test log failures
         if: steps.check_platform.outputs.supported && failure()
         run: |
           set -euo pipefail
           for f in tests/*.log; do
-              echo "::group::$(basename $f)"
-              cat "$f"
-              echo "::endgroup::"
+              if FAIL=$(grep -B100 -A30 "fatal:" "$f"); then
+                  echo "::group::$(basename $f)"
+                  echo "$FAIL"
+                  echo "::endgroup::"
+              fi
           done
 
       - name: Set commit status as success with a description that platform is skipped


### PR DESCRIPTION
Some roles produce ansible/test logs which are too large to sensibly/comfortably view in the main workflow log view. Show only the interesting failures there (the lines around `fatal:`) and upload the full logs as artifact.

---

See [recent run](https://github.com/linux-system-roles/firewall/actions/runs/14405081081/job/40399563001) for example. The primary PR for this is https://github.com/linux-system-roles/.github/pull/99 , this tests it against a real-life project with a failing F42 test.