### PR TITLE
ci: Add container integration test for rpm and bootc

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -65,7 +65,7 @@ jobs:
             tox=tox
             virtualenv=virtualenv
           fi
-          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.7.1"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: QEMU/KVM Integration tests
+name: Test
 on:  # yamllint disable-line rule:truthy
   pull_request:
   merge_group:
@@ -17,18 +17,34 @@ permissions:
   # This is required for the ability to create/update the Pull request status
   statuses: write
 jobs:
-  qemu_kvm:
+  scenario:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         scenario:
+          # QEMU
           - { image: "centos-9", env: "qemu-ansible-core-2.16" }
           - { image: "centos-10", env: "qemu-ansible-core-2.17" }
           # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
           # - { image: "fedora-41", env: "qemu-ansible-core-2.17" }
           - { image: "fedora-42", env: "qemu-ansible-core-2.17" }
+
+          # container
+          - { image: "centos-9", env: "container-ansible-core-2.16" }
+          - { image: "centos-9-bootc", env: "container-ansible-core-2.16" }
+          # broken on non-running dbus
+          # - { image: "centos-10", env: "container-ansible-core-2.17" }
+          - { image: "centos-10-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-41", env: "container-ansible-core-2.17" }
+          - { image: "fedora-42", env: "container-ansible-core-2.17" }
+          - { image: "fedora-41-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-42-bootc", env: "container-ansible-core-2.17" }
+
+    env:
+      TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -38,6 +54,7 @@ jobs:
         run: |
           set -euxo pipefail
           image="${{ matrix.scenario.image }}"
+          image="${image%-bootc}"
 
           # convert image to tag formats
           platform=
@@ -49,6 +66,20 @@ jobs:
           supported=
           if yq -e '.galaxy_info.galaxy_tags[] | select(. == "'${platform_version}'" or . == "'${platform}'")' meta/main.yml; then
             supported=true
+          fi
+
+          # bootc build support (in buildah) has a separate flag
+          if [ "${{ matrix.scenario.image }}" != "$image" ]; then
+            if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
+              supported=
+            fi
+          else
+            # roles need to opt into support for running in a system container
+            env="${{ matrix.scenario.env }}"
+            if [ "${env#container}" != "$env" ] &&
+              ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "container")' meta/main.yml; then
+              supported=
+            fi
           fi
 
           echo "supported=$supported" >> "$GITHUB_OUTPUT"
@@ -82,14 +113,13 @@ jobs:
           curl -o ~/.config/linux-system-roles.json
           https://raw.githubusercontent.com/linux-system-roles/linux-system-roles.github.io/master/download/linux-system-roles.json
 
-      - name: Run qemu/kvm tox integration tests
-        if: steps.check_platform.outputs.supported
-        run: >-
-          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
+      - name: Run qemu integration tests
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu')
+        run: |
+          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch $TOX_ARGS --
 
-      - name: Test result summary
-        if: steps.check_platform.outputs.supported && always()
+      - name: Qemu result summary
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu') && always()
         run: |
           set -euo pipefail
           # some platforms may have setup/cleanup playbooks - need to find the
@@ -108,6 +138,24 @@ jobs:
               fi
               echo "$f"
           done < batch.report
+
+      - name: Run container tox integration tests
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'container')
+        run: |
+          set -euo pipefail
+          # HACK: debug.py/profile.py setup is broken
+          export LSR_CONTAINER_PROFILE=false
+          export LSR_CONTAINER_PRETTY=false
+          rc=0
+          for t in tests/tests_*.yml; do
+              if tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} $t > ${t}.log 2>&1; then
+                  echo "PASS: $(basename $t)"
+              else
+                  echo "FAIL: $(basename $t)"
+                  rc=1
+              fi
+          done
+          exit $rc
 
       - name: Upload test logs on failure
         if: failure()
@@ -139,6 +187,6 @@ jobs:
         uses: myrotvorets/set-commit-status-action@master
         with:
           status: success
-          context: "${{ github.workflow }} / qemu_kvm (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
+          context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
           description: The role does not support this platform. Skipping.
           targetUrl: ""

--- a/.ostree/packages-testing.txt
+++ b/.ostree/packages-testing.txt
@@ -1,1 +1,2 @@
+iputils
 nftables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
     - fedora
     - firewall
     - system
+    - container

--- a/tests/tests_reload_on_reset.yml
+++ b/tests/tests_reload_on_reset.yml
@@ -21,9 +21,12 @@
           set_fact:
             __firewall_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
-    - name: Install podman
+    - name: Install test dependencies
       package:
-        name: podman
+        name:
+          - podman
+          # for ping
+          - iputils
         state: present
         use: "{{ (__firewall_is_ostree | d(false)) |
                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"


### PR DESCRIPTION
Same as in https://github.com/linux-system-roles/sudo/pull/52 to check the new mechanics for a more complex role. This is a case where the role works fine in a system container, but *not* yet during a bootc container build. I'm working on that in my https://github.com/martinpitt/lsr-firewall/tree/bootc-container-test branch, see https://issues.redhat.com/browse/RHEL-88425 . But this is a nice stepping stone.

 - [x] https://github.com/linux-system-roles/tox-lsr/pull/191
 - [x] Release tox-lsr and bump to new release, then remove the extra XXX commit
 - [x] Review/land https://github.com/linux-system-roles/sudo/pull/52 as the initial PR for this machinery