### PR TITLE
test: skip include tests on el7, document el7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,10 +700,11 @@ helper_module: nf_conntrack_ftp
 
 ### includes
 
-Name of one or more services to specify in an `include` in a
-service definition.  The `include` directive is described in the
+Name of one or more services to specify in an `includes` in a
+service definition.  The `includes` directive is described in the
 [service manpage](https://firewalld.org/documentation/man-pages/firewalld.service.html)
 This can only be used when managing service definitions.
+NOTE: `includes` support is only available in EL8 and higher.
 
 ```yaml
 includes:

--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -546,6 +546,9 @@
             permanent: true
           register: result
           failed_when: result is failed or result is not changed
+          when:
+            - ansible_distribution in ["RedHat", "CentOS", "Fedora"]
+            - ansible_distribution_major_version is version("8", ">=")
 
         - name: Add includes again to check idempotence
           firewall_lib:
@@ -557,6 +560,9 @@
             permanent: true
           register: result
           failed_when: result is failed or result is changed
+          when:
+            - ansible_distribution in ["RedHat", "CentOS", "Fedora"]
+            - ansible_distribution_major_version is version("8", ">=")
 
         - name: Delete custom service
           firewall_lib:
@@ -586,9 +592,10 @@
             destination:
               - 123.45.6.78
               - "aaaa:aaaa:aaaa:aaa:aaaa:aaaa:aaaa::"
-            includes:
-              - https
-              - ldaps
+            includes: "{{ ['https', 'ldaps']
+              if ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+              and ansible_distribution_major_version is version('8', '>=')
+              else omit }}"
             permanent: true
             state: present
           register: result

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -69,9 +69,10 @@
                 destination:
                   - 1.1.1.1
                   - 1::1
-                includes:
-                  - ssh
-                  - ldaps
+                includes: "{{ ['ssh', 'ldaps']
+                  if ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+                  and ansible_distribution_major_version is version('8', '>=')
+                  else [] }}"
                 permanent: true
                 state: present
 
@@ -91,9 +92,10 @@
                 destination:
                   - 1.1.1.1
                   - 1::1
-                includes:
-                  - ssh
-                  - ldaps
+                includes: "{{ ['ssh', 'ldaps']
+                  if ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+                  and ansible_distribution_major_version is version('8', '>=')
+                  else [] }}"
                 permanent: true
                 state: present
 
@@ -124,9 +126,10 @@
                   - 1::1
                 helper_module: ftp
                 protocol: icmp
-                includes:
-                  - ssh
-                  - ldaps
+                includes: "{{ ['ssh', 'ldaps']
+                  if ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+                  and ansible_distribution_major_version is version('8', '>=')
+                  else [] }}"
                 permanent: true
                 state: present
 
@@ -167,9 +170,10 @@
                   - 1::1
                 helper_module: ftp
                 protocol: icmp
-                includes:
-                  - ssh
-                  - ldaps
+                includes: "{{ ['ssh', 'ldaps']
+                  if ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+                  and ansible_distribution_major_version is version('8', '>=')
+                  else [] }}"
                 permanent: true
                 state: present
 
@@ -245,9 +249,10 @@
                   - 1::1
                 helper_module: ftp
                 protocol: icmp
-                includes:
-                  - ssh
-                  - ldaps
+                includes: "{{ ['ssh', 'ldaps']
+                  if ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+                  and ansible_distribution_major_version is version('8', '>=')
+                  else [] }}"
                 permanent: true
                 state: absent
 
@@ -271,9 +276,10 @@
                   - 1::1
                 helper_module: ftp
                 protocol: icmp
-                includes:
-                  - ssh
-                  - ldaps
+                includes: "{{ ['ssh', 'ldaps']
+                  if ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+                  and ansible_distribution_major_version is version('8', '>=')
+                  else [] }}"
                 permanent: true
                 state: absent
 


### PR DESCRIPTION
The new `includes` feature is only supported on EL8 and above, not
on EL7.  Document this.  Skip testing includes on EL7.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
