### PR TITLE
ci: Two prerequisites for bootc support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,23 +2,24 @@
 - name: Setup firewalld
   include_tasks: firewalld.yml
 
-- name: Collect service facts
-  service_facts:
+- name: Check which conflicting services are enabled
+  # noqa command-instead-of-module
+  command: systemctl is-enabled "{{ item }}"
+  register: __firewall_conflicting_services_status
+  changed_when: false
+  failed_when: false
+  loop: "{{ __firewall_conflicting_services }}"
   when: firewall_disable_conflicting_services | bool
 
 - name: Attempt to stop and disable conflicting services
   service:
-    name: "{{ item }}"
+    name: "{{ item.item }}"
     state: stopped
     enabled: false
-  loop: "{{ __firewall_conflicting_services }}"
-  vars:
-    __service_name: "{{ (ansible_facts.service_mgr == 'systemd') |
-      ternary(item ~ '.service', item) }}"
+  loop: "{{ __firewall_conflicting_services_status.results }}"
   when:
     - firewall_disable_conflicting_services | bool
-    - __service_name | string in ansible_facts.services
-    - ansible_facts.services[__service_name]["status"] == "enabled"
+    - item.rc == 0
 
 - name: Unmask firewalld service
   systemd:

--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -9,7 +9,7 @@
         name: linux-system-roles.firewall
 
     - name: Get default zone
-      command: firewall-cmd --get-default-zone
+      command: firewall-offline-cmd --get-default-zone
       register: __default_zone
       changed_when: false
 
@@ -19,37 +19,37 @@
         # INIT TEST
 
         - name: Remove custom zone
-          command: firewall-cmd --permanent --delete-zone=custom
+          command: firewall-offline-cmd --delete-zone=custom
           register: result
           failed_when: result.failed and "INVALID_ZONE" not in result.stderr
           changed_when: false
 
         - name: Reset internal zone to defaults
-          command: firewall-cmd --permanent --load-zone-defaults=internal
+          command: firewall-offline-cmd --load-zone-defaults=internal
           register: result
           failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
           changed_when: false
 
         - name: Reset trusted zone to defaults
-          command: firewall-cmd --permanent --load-zone-defaults=trusted
+          command: firewall-offline-cmd --load-zone-defaults=trusted
           register: result
           failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
           changed_when: false
 
         - name: Reset dmz zone to defaults
-          command: firewall-cmd --permanent --load-zone-defaults=dmz
+          command: firewall-offline-cmd --load-zone-defaults=dmz
           register: result
           failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
           changed_when: false
 
         - name: Reset drop zone to defaults
-          command: firewall-cmd --permanent --load-zone-defaults=drop
+          command: firewall-offline-cmd --load-zone-defaults=drop
           register: result
           failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
           changed_when: false
 
         - name: Reset public zone to defaults
-          command: firewall-cmd --permanent --load-zone-defaults=public
+          command: firewall-offline-cmd --load-zone-defaults=public
           register: result
           failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
           changed_when: false
@@ -57,15 +57,15 @@
         - name: Reset default zone to defaults
           shell:
             cmd: |
-              zone=$(firewall-cmd --get-default-zone)
-              firewall-cmd --permanent --load-zone-defaults=$zone
+              zone=$(firewall-offline-cmd --get-default-zone)
+              firewall-offline-cmd --load-zone-defaults=$zone
           register: result
           failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
           changed_when: false
 
         - name: Create custom zone
           # noqa no-changed-when
-          command: firewall-cmd --permanent --new-zone=custom
+          command: firewall-offline-cmd --new-zone=custom
           register: result
           failed_when: result.failed or not result.changed
 
@@ -410,7 +410,12 @@
           failed_when: result is failed or result is changed
 
         - name: Set the default zone to something other than dmz
-          command: firewall-cmd --set-default-zone public
+          # --set-default-zone not idempotent: https://bugzilla.redhat.com/show_bug.cgi?id=2363037
+          shell: |
+            cur_zone=$(firewall-offline-cmd --get-default-zone)
+            if [ "$cur_zone" != public ]; then
+              firewall-offline-cmd --set-default-zone public
+            fi
           changed_when: false
 
         - name: Set default zone
@@ -673,57 +678,60 @@
             # CLEANUP: RESET TO ZONE DEFAULTS
 
             - name: Remove custom zone
-              command: firewall-cmd --permanent --delete-zone=custom
+              command: firewall-offline-cmd --delete-zone=custom
               register: result
               failed_when: result.failed and "INVALID_ZONE" not in result.stderr
               changed_when: false
 
             - name: Remove customzone zone
-              command: firewall-cmd --permanent --delete-zone=customzone
+              command: firewall-offline-cmd --delete-zone=customzone
               register: result
               failed_when: result.failed and "INVALID_ZONE" not in result.stderr
               changed_when: false
 
             - name: Reset internal zone to defaults
-              command: firewall-cmd --permanent --load-zone-defaults=internal
+              command: firewall-offline-cmd --load-zone-defaults=internal
               register: result
               failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
               changed_when: false
 
             - name: Reset trusted zone to defaults
-              command: firewall-cmd --permanent --load-zone-defaults=trusted
+              command: firewall-offline-cmd --load-zone-defaults=trusted
               register: result
               failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
               changed_when: false
 
             - name: Reset dmz zone to defaults
-              command: firewall-cmd --permanent --load-zone-defaults=dmz
+              command: firewall-offline-cmd --load-zone-defaults=dmz
               register: result
               failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
               changed_when: false
 
             - name: Reset drop zone to defaults
-              command: firewall-cmd --permanent --load-zone-defaults=drop
+              command: firewall-offline-cmd --load-zone-defaults=drop
               register: result
               failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
               changed_when: false
 
             - name: Reset public zone to defaults
-              command: firewall-cmd --permanent --load-zone-defaults=public
+              command: firewall-offline-cmd --load-zone-defaults=public
               register: result
               failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
               changed_when: false
 
             - name: Reset default zone to defaults
-              command: firewall-cmd --permanent --load-zone-defaults=public
+              command: firewall-offline-cmd --load-zone-defaults=public
               register: result
               failed_when: result.failed and "NO_DEFAULTS" not in result.stderr
               changed_when: false
 
             - name: Reset default zone
-              command: >-
-                firewall-cmd
-                --set-default-zone={{ __default_zone.stdout | quote }}
+              # --set-default-zone not idempotent: https://bugzilla.redhat.com/show_bug.cgi?id=2363037
+              shell: |
+                cur_zone=$(firewall-offline-cmd --get-default-zone)
+                if [ "$cur_zone" != {{ __default_zone.stdout | quote }} ]; then
+                  firewall-offline-cmd --set-default-zone={{ __default_zone.stdout | quote }}
+                fi
               changed_when: false
 
             - name: Reload firewalld

--- a/tests/tests_firewall_fact.yml
+++ b/tests/tests_firewall_fact.yml
@@ -13,7 +13,7 @@
               - previous: replaced
 
         - name: Get default zone
-          command: firewall-cmd --get-default-zone
+          command: firewall-offline-cmd --get-default-zone
           changed_when: false
           register: __default_zone
 
@@ -64,8 +64,12 @@
         - name: Modify firewalld configuration
           shell:
             cmd: |
-              firewall-cmd --permanent --add-service https
-              firewall-cmd --permanent --new-service custom
+              firewall-offline-cmd --add-service https
+              firewall-offline-cmd --new-service custom
+          changed_when: false
+
+        - name: Reload firewalld in booted systems
+          command: firewall-cmd --reload
           changed_when: false
 
         - name: Refetch firewall_config

--- a/tests/tests_ipsets.yml
+++ b/tests/tests_ipsets.yml
@@ -20,7 +20,7 @@
           shell:
             cmd: |
               set -o pipefail
-              firewall-cmd --permanent --get-ipsets | grep customipset
+              firewall-offline-cmd --get-ipsets | grep customipset
           register: result
           changed_when: false
           failed_when: result.rc != 1
@@ -46,14 +46,14 @@
           shell:
             cmd: |
               set -o pipefail
-              firewall-cmd --permanent --get-ipsets | grep "customipset"
+              firewall-offline-cmd --get-ipsets | grep "customipset"
           changed_when: false
           register: result
           failed_when: result.rc == 1
 
         - name: Fail if entry not added to ipset
           command: |
-            firewall-cmd --permanent --ipset customipset --query-entry 8.8.8.8
+            firewall-offline-cmd --ipset customipset --query-entry 8.8.8.8
           changed_when: false
 
         - name: Redefine new ipset
@@ -89,14 +89,14 @@
           shell:
             cmd: |
               set -o pipefail
-              firewall-cmd --permanent --get-ipsets | grep customipset
+              firewall-offline-cmd --get-ipsets | grep customipset
           changed_when: false
           register: result
           failed_when: result.rc != 0
 
         - name: Check that entry has been removed
           command: >-
-            firewall-cmd --permanent --ipset customipset --query-entry 8.8.8.8
+            firewall-offline-cmd --ipset customipset --query-entry 8.8.8.8
           changed_when: false
           register: result
           failed_when: result.rc != 1
@@ -118,10 +118,10 @@
           register: result
           loop:
             - command: |
-                firewall-cmd --permanent --ipset customipset --get-description
+                firewall-offline-cmd --ipset customipset --get-description
               expected: "Custom IPSet for testing purposes (changed)"
             - command: |
-                firewall-cmd --permanent --ipset customipset --get-short
+                firewall-offline-cmd --ipset customipset --get-short
               expected: "CustomChanged"
           failed_when: result.stdout != item["expected"]
 
@@ -196,7 +196,7 @@
           shell:
             cmd: |
               set -o pipefail
-              firewall-cmd --permanent --get-ipsets | grep "customipset"
+              firewall-offline-cmd --get-ipsets | grep "customipset"
           changed_when: false
           register: result
           failed_when: result.rc != 1

--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -18,7 +18,7 @@
         # Verify service states are as intended
 
         - name: Get all services
-          command: firewall-cmd --permanent --get-services
+          command: firewall-offline-cmd --get-services
           register: result
           changed_when: false
 
@@ -136,7 +136,7 @@
         # Verify that custom service is added to permanent configuration
 
         - name: Get all services
-          command: firewall-cmd --permanent --get-services
+          command: firewall-offline-cmd --get-services
           register: result
           changed_when: false
 
@@ -185,7 +185,7 @@
         # Verify that custom service not a part of default zone for some reason
 
         - name: Query if default zone has custom service added
-          command: firewall-cmd --query-service systemroletest
+          command: firewall-offline-cmd --query-service systemroletest
           ignore_errors: true  # noqa ignore-errors
           register: result
           changed_when: false
@@ -215,7 +215,7 @@
         # Verify that custom service in zone permanent configuration
 
         - name: Query if service has been added to default zone
-          command: firewall-cmd --query-service systemroletest
+          command: firewall-offline-cmd --query-service systemroletest
           register: result
           changed_when: false
 
@@ -289,7 +289,7 @@
           when: firewall_lib_result.changed  # noqa no-handler
 
         - name: Get all services
-          command: firewall-cmd --permanent --get-services
+          command: firewall-offline-cmd --get-services
           register: result
           changed_when: false
 
@@ -312,7 +312,7 @@
                 state: absent
 
         - name: Get all services
-          command: firewall-cmd --permanent --get-services
+          command: firewall-offline-cmd --get-services
           register: result
           changed_when: false
 

--- a/tests/tests_target.yml
+++ b/tests/tests_target.yml
@@ -16,7 +16,7 @@
                 permanent: true
 
         - name: Get target setting
-          command: firewall-cmd --info-zone=public
+          command: firewall-offline-cmd --info-zone=public
           changed_when: false
           register: __result
 
@@ -36,7 +36,7 @@
               permanent: true
 
         - name: Get target setting
-          command: firewall-cmd --info-zone=public
+          command: firewall-offline-cmd --info-zone=public
           changed_when: false
           register: __result
 

--- a/tests/tests_zone.yml
+++ b/tests/tests_zone.yml
@@ -106,7 +106,7 @@
         # VERIFY
 
         - name: Verify firewalld zone internal services
-          command: firewall-cmd --permanent --zone=internal --list-services
+          command: firewall-offline-cmd --zone=internal --list-services
           register: result
           changed_when: false
           failed_when: result.failed
@@ -114,7 +114,7 @@
                       or "ftp" not in result.stdout
 
         - name: Verify firewalld zone internal ports
-          command: firewall-cmd --permanent --zone=internal --list-ports
+          command: firewall-offline-cmd --zone=internal --list-ports
           register: result
           changed_when: false
           failed_when: result.failed
@@ -122,7 +122,7 @@
                       or "443/udp" not in result.stdout
 
         - name: Verify firewalld zone internal forward ports
-          command: firewall-cmd --permanent --zone=internal --list-forward-ports
+          command: firewall-offline-cmd --zone=internal --list-forward-ports
           register: result
           changed_when: false
           failed_when: result.failed
@@ -132,21 +132,21 @@
                           not in result.stdout
 
         - name: Verify custom zone has masquerade added to it
-          command: firewall-cmd --permanent --zone=customzone --query-masquerade
+          command: firewall-offline-cmd --zone=customzone --query-masquerade
           register: result
           changed_when: false
           failed_when: result is failed
                       or "yes" not in result.stdout
 
         - name: Verify custom zone has masquerade added to it
-          command: firewall-cmd --get-default-zone
+          command: firewall-offline-cmd --get-default-zone
           register: result
           changed_when: false
           failed_when: result is failed
                       or "dmz" not in result.stdout
 
         - name: Verify that service http has been added to the default zone dmz
-          command: firewall-cmd --zone=dmz --query-service=http
+          command: firewall-offline-cmd --zone=dmz --query-service=http
           register: result
           changed_when: false
           failed_when: result is failed
@@ -159,7 +159,7 @@
             # CLEANUP: RESET TO ZONE DEFAULTS
 
             - name: Remove customzone zone
-              command: firewall-cmd --permanent --delete-zone=customzone
+              command: firewall-offline-cmd --delete-zone=customzone
               register: result
               failed_when: result.failed and "INVALID_ZONE" not in result.stderr
               changed_when: false
@@ -167,8 +167,11 @@
             - name: Reset to zone defaults
               shell:
                 cmd: |
-                  firewall-cmd --permanent --load-zone-defaults=internal
-                  firewall-cmd --permanent --load-zone-defaults=external
-                  firewall-cmd --permanent --load-zone-defaults=trusted
-                  firewall-cmd --reload
+                  firewall-offline-cmd --load-zone-defaults=internal
+                  firewall-offline-cmd --load-zone-defaults=external
+                  firewall-offline-cmd --load-zone-defaults=trusted || true
+              changed_when: false
+
+            - name: Reload firewall
+              command: firewall-cmd --reload
               changed_when: false


### PR DESCRIPTION
These are two prerequisites for eventual bootc build support. They are [tested](https://github.com/martinpitt/lsr-firewall/actions/workflows/qemu-kvm-integration-tests.yml) in my [bootc-container-test branch](https://github.com/martinpitt/lsr-firewall/tree/refs/heads/bootc-container-test), and so far these parts work fine. These two commits are fairly intrusive but conceptually simple, so it may make sense to already land them. I also want to make sure that it doesn't break any of the qemu/TF tests.

## Summary by Sourcery

Prepare for bootc build support by migrating tests to offline mode and enhancing service handling.

Enhancements:
- Switch all ansible test scripts to use firewall-offline-cmd instead of firewall-cmd for offline configuration
- Replace service_facts with systemctl is-enabled checks and split disable/stop of conflicting services into separate tasks with conditional execution
- Wrap non-idempotent --set-default-zone calls in idempotent shell logic within tests