### PR TITLE
docs(changelog): version 1.10.0 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -719,6 +719,8 @@ interfaces with the PCI id specified will have the play applied.</p>
 <code>lcpci -nn</code>. For more information on PCI device IDs, see the
 linux man page at: <a
 href="https://man7.org/linux/man-pages/man5/pci.ids.5.html">https://man7.org/linux/man-pages/man5/pci.ids.5.html</a></p>
+<p>This option requires running the role on the actual target machine,
+i.e. it is not supported during container builds.</p>
 <h2 id="icmp_block">icmp_block</h2>
 <p>String or list of ICMP type strings to block. The ICMP type names
 needs to be defined in firewalld configuration.</p>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 Changelog
 =========
 
+[1.10.0] - 2025-05-21
+--------------------
+
+### New Features
+
+- feat: Support this role in container builds (#274)
+
+### Bug Fixes
+
+- fix: Fix "helpers" service option (#277)
+- fix: Fix "interface_pci_id" role option (#278)
+
+### Other Changes
+
+- ci: Assert fact structure and some well-known entries (#265)
+- ci: Bump sclorg/testing-farm-as-github-action from 3 to 4 (#268)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#269)
+- ci: Two prerequisites for bootc support (#270)
+- refactor: Add backend abstraction to firewall_lib, remove obsolete firewall_lib offline code (#271)
+- tests: Various fixes and additions (#273)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#275)
+
 [1.9.1] - 2025-04-29
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.10.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare and document the 1.10.0 release with new feature support, bug fixes, CI updates, refactoring, test improvements, and documentation updates.

New Features:
- Add support for using this role in container-based builds

Bug Fixes:
- Fix the "helpers" service option
- Fix the "interface_pci_id" role option

Enhancements:
- Introduce a backend abstraction in firewall_lib and remove obsolete offline code

CI:
- Assert fact structure and key entries in CI jobs
- Bump sclorg/testing-farm-as-github-action from v3 to v4
- Upgrade tox-lsr to v3.8.0 and rename QEMU/KVM tests
- Add prerequisites for bootc support in CI
- Add Fedora 42 testing and upgrade tox-lsr to v3.9.0 with lsr-report-errors for QEMU tests

Documentation:
- Clarify in README that interface_pci_id requires running on the actual target machine and isn’t supported in container builds

Tests:
- Apply various test fixes and additions