### PR TITLE
docs(changelog): version 1.10.1 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+[1.10.1] - 2025-06-23
+--------------------
+
+### Other Changes
+
+- tests: Update tests_zone to do bootc end-to-end validation (#280)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#281)
+
 [1.10.0] - 2025-05-21
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.10.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare and document the 1.10.1 release

CI:
- Use Ansible 2.19 for Fedora 42 testing and add Python 3.13 support

Documentation:
- Add changelog entry and update README.html for version 1.10.1

Tests:
- Update tests_zone to perform bootc end-to-end validation