### PR TITLE
test: debug finding ethernet with pci

### DIFF
--- a/plans/test_playbooks_parallel.fmf
+++ b/plans/test_playbooks_parallel.fmf
@@ -7,8 +7,16 @@ provision:
     role: control_node
   - name: managed-node1
     role: managed_node
+    hardware:
+      network:
+        - type: eth
+        - type: eth
   - name: managed-node2
     role: managed_node
+    hardware:
+      network:
+        - type: eth
+        - type: eth
 environment:
   SR_ANSIBLE_VER: 2.17
   SR_REPO_NAME: firewall

--- a/tests/provision.fmf
+++ b/tests/provision.fmf
@@ -1,0 +1,6 @@
+---
+standard-inventory-qcow2:
+  qemu:
+    # Use qemu-system-x86_64 -net nic,model=help for a list of available devices.
+    net_nic_list:
+      - virtio

--- a/tests/tests_interface_pci.yml
+++ b/tests/tests_interface_pci.yml
@@ -30,11 +30,34 @@
       register: find_iface
       changed_when: false
 
+    - name: Debug
+      shell: |
+        set -euxo pipefail
+        exec 1>&2
+        ip addr
+        ls -alrtF /sys/class/net
+        ls -alrtF /sys/class/net/*/device/vendor || :
+        ls -alrtF /sys/class/net/*/device/device || :
+      changed_when: false
+
     - name: Test interfaces with PCI ids
       # this can't be tested in containers or similar envs without any real
       # ethernet devices
       when: find_iface.stdout != ""
       block:
+        - name: Get temp directory
+          tempfile:
+            prefix: lsr_
+            suffix: _firewall_pci
+            state: directory
+          register: temp_dir
+
+        - name: Debug - get nftables ruleset before
+          shell: |
+            set -euo pipefail
+            nft list ruleset > {{ temp_dir.path }}/nft_before.txt || :
+          changed_when: false
+
         - name: Determine interface vendor/product ID
           shell: |
             set -euo pipefail
@@ -63,6 +86,14 @@
               interface_pci_id: "{{ pci_id.stdout }}"
               state: enabled
               permanent: true
+
+        - name: Debug - get nftables ruleset after and show diff
+          shell: |
+            set -euo pipefail
+            nft list ruleset > {{ temp_dir.path }}/nft_after.txt || :
+            diff -u {{ temp_dir.path }}/nft_before.txt {{ temp_dir.path }}/nft_after.txt || :
+            rm -rf {{ temp_dir.path }}
+          changed_when: false
 
         - name: Get nftable ruleset
           command: nft list ruleset


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhance the PCI interface test to provide verbose debugging output for detecting Ethernet devices and introduce a new provisioning configuration file.

Tests:
- Enable shell debug mode and redirect output in the PCI interface test
- Install pciutils and output lspci, network addresses, and sysfs device info
- Add tests/provision.fmf file for test provisioning