### PR TITLE
test: allow unicode literals for ansible-test

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -17,6 +17,7 @@ kinds:
 skip_list:
   - fqcn-builtins
   - var-naming[no-role-prefix]
+  - sanity[cannot-ignore]  # wokeignore:rule=sanity
 exclude_paths:
   - tests/roles/
   - .github/

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -1,2 +1,5 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib.py no-unicode-literals!skip
+plugins/modules/firewall_lib.py future-import-boilerplate!skip
+tests/firewall/unit/test_firewall_lib.py no-unicode-literals!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -1,2 +1,5 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib.py no-unicode-literals!skip
+plugins/modules/firewall_lib.py future-import-boilerplate!skip
+tests/firewall/unit/test_firewall_lib.py no-unicode-literals!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,2 +1,6 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib.py no-unicode-literals!skip
+plugins/modules/firewall_lib.py future-import-boilerplate!skip
+plugins/modules/firewall_lib.py validate-modules:illegal-future-imports
+tests/firewall/unit/test_firewall_lib.py no-unicode-literals!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -1,2 +1,5 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib.py no-unicode-literals!skip
+plugins/modules/firewall_lib.py future-import-boilerplate!skip
+tests/firewall/unit/test_firewall_lib.py no-unicode-literals!skip

--- a/.sanity-ansible-ignore-2.16.txt
+++ b/.sanity-ansible-ignore-2.16.txt
@@ -1,2 +1,5 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib.py no-unicode-literals!skip
+plugins/modules/firewall_lib.py future-import-boilerplate!skip
+tests/firewall/unit/test_firewall_lib.py no-unicode-literals!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,2 +1,5 @@
 plugins/modules/firewall_lib.py validate-modules:missing-gplv3-license
 plugins/modules/firewall_lib_facts.py validate-modules:missing-gplv3-license
+plugins/modules/firewall_lib.py no-unicode-literals!skip
+plugins/modules/firewall_lib.py future-import-boilerplate!skip
+tests/firewall/unit/test_firewall_lib.py no-unicode-literals!skip


### PR DESCRIPTION
The code uses ipaddress which requires unicode literals.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Added unicode-literal ignore entries to .sanity-ansible-ignore files for Ansible versions 2.9 through 2.16.