### PR TITLE
docs(changelog): version 1.11.1 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.11.1] - 2025-10-22
+--------------------
+
+### Other Changes
+
+- test: allow unicode literals for ansible-test (#298)
+
 [1.11.0] - 2025-10-21
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.11.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document the 1.11.1 release by adding a new changelog entry and updating the README

Enhancements:
- allow unicode literals in ansible-test (#298)

Documentation:
- add CHANGELOG entry for version 1.11.1 dated 2025-10-22
- update README.html to reference version 1.11.1