### PR TITLE
fix: install python311-firewall on SLES 15

### DIFF
--- a/vars/SLES_15.yml
+++ b/vars/SLES_15.yml
@@ -1,0 +1,4 @@
+---
+# Put internal variables here with SLES_15 specific values.
+
+__firewall_packages_extra: [python311-firewall]

--- a/vars/SLES_SAP_15.yml
+++ b/vars/SLES_SAP_15.yml
@@ -1,0 +1,4 @@
+---
+# Put internal variables here with SLES_SAP_15 specific values.
+
+__firewall_packages_extra: [python311-firewall]


### PR DESCRIPTION
Enhancement: Fix role failure on SLES 15. Added Distro specific vars to include missing package.

Reason: Role fails on SLES15 requires python311-firewall package which is not installed by default by the firewalld package.

Result: Distro specific vars install python311-firewall for SLES 15

Issue Tracker Tickets (Jira or BZ if any): NA

## Summary by Sourcery

Bug Fixes:
- Add SLES_15 and SLES_SAP_15 vars files to install python311-firewall