### PR TITLE
docs(changelog): version 1.11.3 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.11.3] - 2025-11-17
+--------------------
+
+### Bug Fixes
+
+- fix: cannot use community-general version 12 - no py27 and py36 support (#307)
+
 [1.11.2] - 2025-11-13
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.11.3

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Documentation:
- Add changelog entry and update README for version 1.11.3 with the fix for community-general version 12 support lacking py27 and py36