### PR TITLE
fix: add verbosity-based no_log to facts modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,6 +92,7 @@
             online: "{{ __firewall_is_booted }}"
             detailed: "{{ firewall_detailed_facts }}"
           register: __firewalld_facts
+          no_log: "{{ ansible_verbosity < 2 }}"
 
         - name: Update firewalld_config fact
           set_fact:


### PR DESCRIPTION
Feature: Add verbosity-based no_log to facts modules.

Reason: Facts modules like firewall_lib_facts produce verbose output that clutters logs during normal operation, making it difficult to review playbook execution.

Result:
  - firewall_lib_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - Users can still see full facts output when debugging by running with increased verbosity
  - No impact on normal operation, just cleaner logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Add verbosity-based no_log to firewall facts task so detailed facts are only logged at -vv or higher.