### PR TITLE
docs(changelog): version 1.12.1 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.12.1] - 2026-05-07
+--------------------
+
+### Bug Fixes
+
+- fix: add verbosity-based no_log to facts modules (#349)
+
+### Other Changes
+
+- ci: bump actions/github-script from 8 to 9 (#347)
+
 [1.12.0] - 2026-04-28
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.12.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update changelog for the 1.12.1 release.

Bug Fixes:
- Document bug fix adding verbosity-based no_log to facts modules.

CI:
- Document CI change bumping actions/github-script from v8 to v9.