### PR TITLE
fix: role should not configure firewall if only getting facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,16 +40,11 @@
     state: "{{ 'started' if __firewall_is_booted else omit }}"
   check_mode: "{{ __firewall_test_check_mode | d(ansible_check_mode) }}"
 
-# NOTE: The old implementation of this role would always set permanent to True if it was not set,
-# and would set runtime to True if it was not set
-# so replicate that behavior here in order to maintain backwards compatibility in the module
-# in case someone is erroneously using the module directly
 - name: Configure firewall and/or gather facts
   vars:
     firewall_config_list: "{{ firewall is mapping | ternary([firewall], firewall) | list
       if firewall is not none else [] }}"
-    firewall_lib_config_list: "{{ firewall_config_list | map('dict2items') | map('rejectattr', 'key', 'match', '^detailed$') |
-        map('list') | map('items2dict') | list }}"
+    firewall_lib_config_list: "{{ firewall_config_list | map('dict2items') | map('rejectattr', 'key', 'match', '^detailed$') | map('list') | select | map('items2dict') | list }}"
     _detailed:
       detailed: true
     firewall_detailed_facts: "{{ firewall == _detailed or firewall == [_detailed] }}"


### PR DESCRIPTION
Enhancement:

When calling the firewall role with detailed: true, the configure task is incorrectly called, instead of skipped.

```
- role: fedora.linux_system_roles.firewall
    debugger: always
    firewall:
      detailed: true
```

Resulting firewall_lib_config_list contains an empty dict therefor `firewall_lib_config_list | length > 0`
```
ansible -m debug -e '{ "firewall_config_list": [ { "detailed": true } ] }' -a msg="{{  firewall_config_list | map('dict2items') | map('rejectattr', 'key', 'match', '^detailed$') | map('list') |  map('items2dict') | list | to_json  }}" localhost

localhost | SUCCESS => 
    msg: '[{}]'
```

```
ansible -m debug -e '{ "firewall_config_list": [ { "detailed": true } ] }' -a msg="{{  firewall_config_list | map('dict2items') | map('rejectattr', 'key', 'match', '^detailed$') | map('list') | reject('eq', []) |  map('items2dict') | list | to_json  }}" localhost

localhost | SUCCESS => 
    msg: '[]'
```

Reason: Bug
Result: Detailed fact collection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved firewall configuration processing for more consistent and reliable results: entries labeled as purely "detailed" are now ignored, empty configuration blocks are omitted, and overall handling of configuration lists has been streamlined to reduce spurious or empty outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->