### PR TITLE
fix: ensure firewall_config is reset

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,10 @@
         - firewall_lib_result.short_circuit is defined
         - not firewall_lib_result.short_circuit | bool
 
+    - name: Reset firewall_config
+      set_fact:
+        firewall_config: {}
+
     - name: Gather firewall ansible facts if no args
       when: firewall_lib_config_list | length == 0
       block:


### PR DESCRIPTION
Cause: The variable firewall_config is not being reset in the case where it was previously
requested, and the user runs the role again without requesting facts.

Consequence: firewall_config is set to the old value, so if the user uses it, they will get
the facts from the previous run.

Fix: Ensure that firewall_config is always set or reset by the role.

Result: The user will either get the current facts from firewall_config, or firewall_config
will be empty after a reset, and the user will not accidentally be using old facts.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firewall configuration initialization to ensure proper state reset before gathering configuration facts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->