### PR TITLE
fix: ensure rich rule handling is idempotent

### DIFF
--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -1948,6 +1948,8 @@ class InMemoryBackend:
                     zone_config["masquerade"] = masquerade
                     self.changed = True
 
+    # note: rich_rule is a single string, normalized using str(Rich_Rule(rule_str=original_string))
+    # the zone config field 'rich_rule' is a list of normalized strings
     def set_rich_rule(self, rich_rule):
         """Configure rich rules in a zone."""
         for config_type, zone_config in (
@@ -1957,12 +1959,12 @@ class InMemoryBackend:
             if config_type and zone_config is not None:
                 for item in rich_rule:
                     if self.state == "enabled":
-                        if item not in zone_config.get("rich_rules", []):
-                            zone_config.setdefault("rich_rules", []).append(item)
+                        if item not in zone_config.get("rich_rule", []):
+                            zone_config.setdefault("rich_rule", []).append(item)
                             self.changed = True
                     elif self.state == "disabled":
-                        if item in zone_config.get("rich_rules", []):
-                            zone_config["rich_rules"].remove(item)
+                        if item in zone_config.get("rich_rule", []):
+                            zone_config["rich_rule"].remove(item)
                             self.changed = True
 
     def set_source(self, source):
@@ -2481,7 +2483,7 @@ class OfflineCLIBackend:
         enable = self.check_state(["enabled", "disabled"], "rich_rule")
 
         for item in rich_rule:
-            # note: item is a Rich_Rule object, but its __str__() does the right thing
+            # note: item is a string, normalized using str(Rich_Rule(rule_str=original_string))
             cur = self.query("--zone", self.zone, "--query-rich-rule=" + item)
 
             if cur != enable:

--- a/module_utils/firewall_lsr/get_config.py
+++ b/module_utils/firewall_lsr/get_config.py
@@ -33,7 +33,7 @@ import sys
 try:
     import firewall.config
 
-    from firewall.client import FirewallClient
+    from firewall.client import FirewallClient, Rich_Rule
 
     # firewall.core.io modules needed for xml file reading
     from firewall.core.io.zone import zone_reader
@@ -97,6 +97,11 @@ def export_config_dict(io_object):
                 object_dict["forward_ports"] = normalize_forward_ports(
                     object_dict["forward_ports"]
                 )
+            if object_dict.get("rules_str"):
+                object_dict["rich_rule"] = [
+                    str(Rich_Rule(rule_str=rule)) for rule in object_dict["rules_str"]
+                ]
+                del object_dict["rules_str"]
         return object_dict
     else:
         return {}
@@ -176,15 +181,13 @@ def fetch_settings_using_offline_cmd(module, setting_name):
                 element_settings["sources"] = offline_cmd(
                     module, ["--zone=" + item, "--list-sources"], defaults=True
                 ).split()
-                element_settings["rules_str"] = (
-                    offline_cmd(
+                rich_rules = [
+                    str(Rich_Rule(rule_str=rule))
+                    for rule in offline_cmd(
                         module, ["--zone=" + item, "--list-rich-rules"], defaults=True
                     ).split("\n")
-                    if offline_cmd(
-                        module, ["--zone=" + item, "--list-rich-rules"], defaults=True
-                    )
-                    else []
-                )
+                ]
+                element_settings["rich_rule"] = rich_rules
 
                 # Query masquerade (returns yes/no or error)
                 try:
@@ -386,15 +389,13 @@ def fetch_settings_using_offline_cmd(module, setting_name):
                     module, ["--policy=" + item, "--list-forward-ports"], defaults=True
                 ).split()
 
-                element_settings["rules_str"] = (
-                    offline_cmd(
+                rich_rules = [
+                    str(Rich_Rule(rule_str=rule))
+                    for rule in offline_cmd(
                         module, ["--policy=" + item, "--list-rich-rules"], defaults=True
                     ).split("\n")
-                    if offline_cmd(
-                        module, ["--policy=" + item, "--list-rich-rules"], defaults=True
-                    )
-                    else []
-                )
+                ]
+                element_settings["rich_rule"] = rich_rules
 
                 # Get ingress/egress zones
                 try:
@@ -905,7 +906,10 @@ def fetch_online_settings(fw, setting_list, detailed=False):
                         element_settings["forward_ports"] = element.getForwardPorts()
                         element_settings["interfaces"] = element.getInterfaces()
                         element_settings["sources"] = element.getSources()
-                        element_settings["rules_str"] = element.getRichRules()
+                        element_settings["rich_rule"] = [
+                            str(Rich_Rule(rule_str=rule))
+                            for rule in element.getRichRules()
+                        ]
                         element_settings["protocols"] = element.getProtocols()
                         element_settings["source_ports"] = element.getSourcePorts()
                         element_settings["icmp_block_inversion"] = (
@@ -916,6 +920,12 @@ def fetch_online_settings(fw, setting_list, detailed=False):
                         element_settings["forward_ports"] = normalize_forward_ports(
                             element_settings["forward_ports"]
                         )
+                    if "rules_str" in element_settings:
+                        element_settings["rich_rule"] = [
+                            str(Rich_Rule(rule_str=rule))
+                            for rule in element_settings["rules_str"]
+                        ]
+                        del element_settings["rules_str"]
                 elif setting_name == "services":
                     element = fw.getServiceSettings(_item)
                     try:
@@ -1058,6 +1068,7 @@ def fetch_settings_from_xml_files(module, setting_list, defaults=False):
     return all_settings
 
 
+# currently unused
 def fetch_settings_from_dir(directory, detailed=False, fw=None):
     setting_options = [
         _file[:-4] for _file in os.listdir(directory) if _file.endswith(".xml")
@@ -1085,7 +1096,9 @@ def fetch_settings_from_dir(directory, detailed=False, fw=None):
                     element_settings["forward_ports"] = element.getForwardPorts()
                     element_settings["interfaces"] = element.getInterfaces()
                     element_settings["sources"] = element.getSources()
-                    element_settings["rules_str"] = element.getRichRules()
+                    element_settings["rich_rule"] = [
+                        str(Rich_Rule(rule_str=rule)) for rule in element.getRichRules()
+                    ]
                     element_settings["protocols"] = element.getProtocols()
                     element_settings["source_ports"] = element.getSourcePorts()
                     element_settings["icmp_block_inversion"] = (

--- a/tests/tests_zone.yml
+++ b/tests/tests_zone.yml
@@ -45,12 +45,14 @@
                 forward_port: ['447/tcp;;1.2.3.4',
                                '448/tcp;;1.2.3.5']
                 state: 'enabled'
+                rich_rule: 'rule family="ipv4" source address="192.0.2.0/24" reject'
               - zone: 'internal'
                 service: ['tftp', 'ftp']
                 port: ['443/tcp', '443/udp']
                 forward_port: ['447/tcp;;1.2.3.4',
                                '448/tcp;;1.2.3.5']
                 state: 'enabled'
+                rich_rule: 'rule family="ipv4" source address="192.0.2.0/24" reject'
               - zone: customzone
                 state: present
               - zone: customzone
@@ -94,12 +96,14 @@
                 forward_port: ['447/tcp;;1.2.3.4',
                                '448/tcp;;1.2.3.5']
                 state: 'enabled'
+                rich_rule: 'rule family="ipv4" source address="192.0.2.0/24" reject'
               - zone: 'internal'
                 service: ['tftp', 'ftp']
                 port: ['443/tcp', '443/udp']
                 forward_port: ['447/tcp;;1.2.3.4',
                                '448/tcp;;1.2.3.5']
                 state: 'enabled'
+                rich_rule: 'rule family="ipv4" source address="192.0.2.0/24" reject'
               - zone: customzone
                 state: present
               - zone: customzone
@@ -146,12 +150,14 @@
                 forward_port: ['447/tcp;;1.2.3.4',
                                '448/tcp;;1.2.3.5']
                 state: 'enabled'
+                rich_rule: 'rule family="ipv4" source address="192.0.2.0/24" reject'
               - zone: 'internal'
                 service: ['tftp', 'ftp']
                 port: ['443/tcp', '443/udp']
                 forward_port: ['447/tcp;;1.2.3.4',
                                '448/tcp;;1.2.3.5']
                 state: 'enabled'
+                rich_rule: 'rule family="ipv4" source address="192.0.2.0/24" reject'
               - zone: customzone
                 state: present
               - zone: customzone
@@ -198,7 +204,7 @@
           command: firewall-offline-cmd --zone=internal --list-services
           register: result
           changed_when: false
-          failed_when: result.failed
+          failed_when: result is failed
                       or "tftp" not in result.stdout
                       or "ftp" not in result.stdout
 
@@ -206,7 +212,7 @@
           command: firewall-offline-cmd --zone=internal --list-ports
           register: result
           changed_when: false
-          failed_when: result.failed
+          failed_when: result is failed
                       or "443/tcp" not in result.stdout
                       or "443/udp" not in result.stdout
 
@@ -214,7 +220,7 @@
           command: firewall-offline-cmd --zone=internal --list-forward-ports
           register: result
           changed_when: false
-          failed_when: result.failed
+          failed_when: result is failed
                       or "port=447:proto=tcp:toport=:toaddr=1.2.3.4"
                           not in result.stdout
                       or "port=448:proto=tcp:toport=:toaddr=1.2.3.5"
@@ -240,6 +246,13 @@
           changed_when: false
           failed_when: result is failed
                       or "yes" not in result.stdout
+
+        - name: Verify rich rule has been added to the internal zone
+          command: firewall-offline-cmd --zone=internal --list-rich-rules
+          register: result
+          changed_when: false
+          failed_when: result is failed
+                      or 'rule family="ipv4" source address="192.0.2.0/24" reject' not in result.stdout
 
         - name: Fail if ipsets not added
           shell:


### PR DESCRIPTION
Cause: The in-memory backend was using a key 'rich_rule' for handling the rich
rules, but the code in get_config was using 'rules_str'.

Consequence: The firewall module added the rich rule every time to the 'rich_rule'
key, ignoring the 'rules_str' key, and was not idempotent.

Fix: Ensure that the key 'rich_rule' is used everywhere.  When reading the information
from the firewall api, ensure that the data under the key 'rules_str' is normalized
and added to the 'rich_rule' key.

Result: The firewall role can manage rich rules idempotently.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

Fixes: https://github.com/linux-system-roles/firewall/issues/357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Normalized firewall rich-rule handling so rules are stored and presented consistently as standardized strings across backends and configuration retrieval.

* **Tests**
  * Added/updated playbook checks to verify rich-rule presence and offline/online listing for firewall zones, including exact-match verification of an IPv4 reject rich rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->