### PR TITLE
fix: ignore network device interface file that is not found

### DIFF
--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -2599,8 +2599,13 @@ def get_interface_pci():
         device_udi = nm_get_client().get_device_by_iface(interface).get_udi()
         device_path = os.path.join(device_udi, "device")
         for field in ["vendor", "device"]:
-            with open(os.path.join(device_path, field)) as _file:
-                interface_ids.append(_file.readline().strip(" \n")[2:])
+            try:
+                with open(os.path.join(device_path, field)) as _file:
+                    interface_ids.append(_file.readline().strip(" \n")[2:])
+            except IOError:
+                continue
+        if len(interface_ids) != 2:
+            continue
         interface_ids = ":".join(interface_ids)
         if interface_ids not in pci_dict:
             pci_dict[interface_ids] = [interface]

--- a/tests/tests_interface_pci.yml
+++ b/tests/tests_interface_pci.yml
@@ -156,6 +156,10 @@
                 interface_pci_id: "{{ pci_id }}"
                 state: enabled
 
+        - name: Debug0
+          debug:
+            msg: result {{ firewall_lib_result | to_nice_json }}
+
         - name: Confirm changes were not made and short circuit is false
           assert:
             that:

--- a/tests/unit/test_firewall_lib.py
+++ b/tests/unit/test_firewall_lib.py
@@ -564,6 +564,42 @@ class FirewallInterfaceTests(unittest.TestCase):
 
         assert result is None
 
+    @patch("firewall_lib.open", create=True)
+    @patch("firewall_lib.nm_get_client", create=True)
+    @patch("firewall_lib.nm_get_interfaces", create=True)
+    def test_get_interface_pci_file_not_found(
+        self, nm_get_interfaces, nm_get_client, mock_open
+    ):
+        nm_get_interfaces.return_value = ["eth0", "eth1"]
+
+        def get_device(iface):
+            device = Mock()
+            device.get_udi.return_value = "/sys/devices/pci/{0}".format(iface)
+            return device
+
+        nm_get_client.return_value.get_device_by_iface.side_effect = get_device
+
+        def open_side_effect(path):
+            if path.endswith("eth1/device/vendor"):
+                mock_file = MagicMock()
+                mock_file.__enter__ = Mock(return_value=mock_file)
+                mock_file.__exit__ = Mock(return_value=False)
+                mock_file.readline.return_value = "0x8086\n"
+                return mock_file
+            if path.endswith("eth1/device/device"):
+                mock_file = MagicMock()
+                mock_file.__enter__ = Mock(return_value=mock_file)
+                mock_file.__exit__ = Mock(return_value=False)
+                mock_file.readline.return_value = "0x1234\n"
+                return mock_file
+            raise IOError(2, "No such file or directory", path)
+
+        mock_open.side_effect = open_side_effect
+
+        result = firewall_lib.get_interface_pci()
+
+        assert result == {"8086:1234": ["eth1"]}
+
     @patch("firewall_lib.NM_IMPORTED", True)
     @patch("firewall_lib.AnsibleModule", new_callable=MockAnsibleModule)
     @patch("firewall_lib.HAS_FIREWALLD", True)


### PR DESCRIPTION
Cause: There seems to be a race condition in some cases where networkmanager
thinks there is a device but the system path is not found.

Consequence: The firewall role can issue an error when attempting to
manage a network interface by PCI ID.

Fix: If the file cannot be found, then it is not a valid device and
can be skipped, so skip it.

Result: The firewall role can manage network interfaces by PCI ID
without errors when there are race conditions.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

Assisted-by: Cursor IDE using the models Composeer 2.5, Sonnet 4.6, Codex 5.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when collecting interface PCI data: unreadable or missing device info is skipped so overall interface collection continues.

* **Tests**
  * Added unit test verifying inaccessible PCI info is ignored and mappings include only successful reads.
  * Added an automated test debug step to display current PCI collection results during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->