### PR TITLE
test: improve tests_reload_on_reset output

### DIFF
--- a/tests/files/test_ping.sh
+++ b/tests/files/test_ping.sh
@@ -59,7 +59,6 @@ podman exec test-firewalld systemctl restart firewalld.service
 wait "$pid"
 
 # Print Results
-tail -2 /tmp/ping0 | head -1 | awk '{print $4}'
-tail -2 /tmp/ping1 | head -1 | awk '{print $4}'
-tail -2 /tmp/ping2 | head -1 | awk '{print $4}'
-
+tail -2 /tmp/ping0 | head -1 | awk '{print "sr_test_coherence=" $4}'
+tail -2 /tmp/ping1 | head -1 | awk '{print "sr_test_reload=" $4}'
+tail -2 /tmp/ping2 | head -1 | awk '{print "sr_test_restart=" $4}'

--- a/tests/tests_reload_on_reset.yml
+++ b/tests/tests_reload_on_reset.yml
@@ -39,13 +39,21 @@
         executable: /bin/bash
       register: test_results
       environment:
-        TEST_DEBUG: "{{ lookup('env', 'TEST_DEBUG') }}"
+        TEST_DEBUG: "true"
+
+    - name: Debug
+      debug:
+        msg: "Coherence check: {{ coherence_check }}, Restart check: {{ restart_check }}, Reload check: {{ reload_check }}"
+      vars:
+        coherence_check: "{{ (test_results.stdout_lines | select('search', 'sr_test_coherence=') | first).split('=') | last | int }}"
+        restart_check: "{{ (test_results.stdout_lines | select('search', 'sr_test_restart=') | first).split('=') | last | int }}"
+        reload_check: "{{ (test_results.stdout_lines | select('search', 'sr_test_reload=') | first).split('=') | last | int }}"
 
     - name: Process test results
       vars:
-        coherence_check: "{{ test_results.stdout_lines[0] }}"
-        restart_check: "{{ test_results.stdout_lines[2] }}"
-        reload_check: "{{ test_results.stdout_lines[1] }}"
+        coherence_check: "{{ (test_results.stdout_lines | select('search', 'sr_test_coherence=') | first).split('=') | last | int }}"
+        restart_check: "{{ (test_results.stdout_lines | select('search', 'sr_test_restart=') | first).split('=') | last | int }}"
+        reload_check: "{{ (test_results.stdout_lines | select('search', 'sr_test_reload=') | first).split('=') | last | int }}"
       fail:
         msg: Either coherence check or benchmark failed
       when: >-


### PR DESCRIPTION
Use TEST_DEBUG=true by default so that we can see what happened if there is
a failure.

Name the output fields so we know what they are.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Tests**
- Updated test output format to explicitly emit key=value structured variables for improved parsing reliability and downstream integration.
- Enhanced test configuration with tag-based output parsing instead of fixed indices, delivering more deterministic behavior when debug mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->