### PR TITLE
fix: ensure firewalld is responding to requests after starting

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,15 @@
     state: "{{ 'started' if __firewall_is_booted else omit }}"
   check_mode: "{{ __firewall_test_check_mode | d(ansible_check_mode) }}"
 
+- name: Check if firewalld is responding to dbus requests
+  # noqa command-instead-of-module
+  command: firewall-cmd --state
+  register: __firewall_cmd_state
+  changed_when: false
+  until: __firewall_cmd_state.stdout | trim == "running"
+  when: __firewall_is_booted
+  check_mode: false  # firewall_lib uses firewalld in check mode
+
 - name: Configure firewall and/or gather facts
   vars:
     firewall_config_list: "{{ firewall is mapping | ternary([firewall], firewall) | list


### PR DESCRIPTION
Cause: The firewalld can be slow to start up on some platforms.

Consequence: The firewall module can be called before the server is responding and
will raise an error if it cannot connect to the firewall daemon.

Fix: Ensure that firewall-cmd --state returns "running" before calling
the module.

Result: The firewall role works even if the server is slow to startup.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firewall startup handling by waiting until the service is fully running before continuing, reducing the chance of follow-up tasks failing due to an unready firewall state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->