### PR TITLE
ci: Add support for Fedora 44 and drop Fedora 42 - use ansible-core 2.21

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
+          pip3 install "git+https://github.com/richm/tox-lsr@runcontainer-use-podman-init-flag"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
+          pip3 install "git+https://github.com/richm/tox-lsr@runcontainer-use-podman-init-flag"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
+          pip3 install "git+https://github.com/richm/tox-lsr@runcontainer-use-podman-init-flag"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -70,7 +70,7 @@ jobs:
             tox=tox
             virtualenv=virtualenv
           fi
-          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
+          pip install "$tox" "$virtualenv" "git+https://github.com/richm/tox-lsr@runcontainer-use-podman-init-flag"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -30,8 +30,8 @@ jobs:
           # QEMU
           - { image: "centos-9", env: "qemu-ansible-core-2-16" }
           - { image: "centos-10", env: "qemu-ansible-core-2-17" }
-          - { image: "fedora-42", env: "qemu-ansible-core-2-19" }
           - { image: "fedora-43", env: "qemu-ansible-core-2-20" }
+          - { image: "fedora-44", env: "qemu-ansible-core-2-21" }
           - { image: "leap-15.6", env: "qemu-ansible-core-2-18" }
 
           # container
@@ -40,10 +40,10 @@ jobs:
           # broken on non-running dbus
           # - { image: "centos-10", env: "container-ansible-core-2-17" }
           - { image: "centos-10-bootc", env: "container-ansible-core-2-17" }
-          - { image: "fedora-42", env: "container-ansible-core-2-17" }
           - { image: "fedora-43", env: "container-ansible-core-2-20" }
-          - { image: "fedora-42-bootc", env: "container-ansible-core-2-17" }
+          - { image: "fedora-44", env: "container-ansible-core-2-21" }
           - { image: "fedora-43-bootc", env: "container-ansible-core-2-20" }
+          - { image: "fedora-44-bootc", env: "container-ansible-core-2-21" }
 
     env:
       TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
@@ -110,29 +110,24 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.20.0"
+          pip3 install "git+https://github.com/richm/tox-lsr@runcontainer-use-podman-init-flag"
 
-      # HACK: Drop this when moving this workflow to 26.04 LTS
-      - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5
-        if: steps.check_platform.outputs.supported && endsWith(matrix.scenario.image, '-bootc')
+      - name: Check for podman version 5 or higher
+        id: check_podman_version
+        if: steps.check_platform.outputs.supported
         run: |
-          sed 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources | sudo tee /etc/apt/sources.list.d/plucky.sources >/dev/null
-          cat <<EOF | sudo tee /etc/apt/preferences.d/podman.pref >/dev/null
-          Package: podman buildah golang-github-containers-common crun libgpgme11t64 libgpg-error0 golang-github-containers-image catatonit conmon containers-storage
-          Pin: release n=plucky
-          Pin-Priority: 991
+          podman_version=$(podman version -f '{{.Client.Version}}')
+          podman_major_version="${podman_version%%.*}"
+          echo "Podman version: $podman_version"
+          if [ "$podman_major_version" -lt 5 ]; then
+            echo "need_podman_update=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "need_podman_update=0" >> "$GITHUB_OUTPUT"
+          fi
 
-          Package: libsubid4 netavark passt aardvark-dns containernetworking-plugins libslirp0 slirp4netns
-          Pin: release n=plucky
-          Pin-Priority: 991
-
-          Package: *
-          Pin: release n=plucky
-          Pin-Priority: 400
-          EOF
-
-          sudo apt update
-          sudo apt install -y podman crun conmon containers-storage
+      - name: Ensure use of podman 5
+        if: steps.check_platform.outputs.supported && steps.check_podman_version.outputs.need_podman_update == 1
+        uses: redhat-actions/podman-install@main
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -72,8 +72,8 @@ jobs:
           meta_main=meta/main.yml
           # All Fedora are supported, add latest Fedora versions to supported_platforms
           if yq '.galaxy_info.galaxy_tags[]' "$meta_main" | grep -qi fedora$; then
-            supported_platforms+=" Fedora-42"
             supported_platforms+=" Fedora-43"
+            supported_platforms+=" Fedora-44"
           fi
           # Specific Fedora versions supported
           if yq '.galaxy_info.galaxy_tags[]' "$meta_main" | grep -qiP 'fedora\d+$'; then
@@ -99,10 +99,10 @@ jobs:
       matrix:
         include:
           # Ensure ansible version is a string!
-          - platform: Fedora-42
-            ansible_version: "2.19"
           - platform: Fedora-43
             ansible_version: "2.20"
+          - platform: Fedora-44
+            ansible_version: "2.21"
           - platform: CentOS-7-latest
             ansible_version: "2.9"
           - platform: CentOS-Stream-8


### PR DESCRIPTION
It's time to test with F44 and drop F42.

Use ansible-core 2.21 for testing - this is now the latest stable version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration testing to cover Fedora 43 and Fedora 44 across QEMU and container scenarios.
  * Updated testing coverage to use newer Ansible versions on Fedora 43 and Fedora 44.
  * Improved Podman setup by checking the installed version and installing a newer version when required.

* **Chores**
  * Updated automated test workflows to use the latest tox-lsr tooling revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->