### PR TITLE
ci: ensure dependabot updates do not invoke ci tests [citest_skip]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     schedule:
       interval: monthly
     commit-message:
-      prefix: ci
+      prefix: "ci: [citest_skip] "


### PR DESCRIPTION
dependabot updates are DoSing our ci tests - we have a limited number of github
action jobs and a dependabot update can eat up all of those for several hours,
causing problems for "real" PRs that we need testing for immediately.

Instead, tell these updates to skip ci testing, and we will manually
trigger specific roles/tests as needed when there is a dependabot update.

see https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#prefix
for more information.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
