### PR TITLE
feat: Add argument spec validation to Firewall role

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ JSON representation of the structure of firewall_config fact:
 
 ## Variables
 
+Validation is enforced by `meta/argument_specs.yml` and
+`tasks/assert_role_vars.yml`.
+
 ### firewall_disable_conflicting_services
 
 By default, the firewall role does not attempt to disable conflicting services due to the

--- a/README.md
+++ b/README.md
@@ -120,6 +120,26 @@ JSON representation of the structure of firewall_config fact:
 Validation is enforced by `meta/argument_specs.yml` and
 `tasks/assert_role_vars.yml`.
 
+| Variable | Type | Default | Accepted values |
+|----------|------|---------|-----------------|
+| `firewall` | raw | `[]` | A list of dicts, a single dict, or `null` |
+| `firewall_disable_conflicting_services` | bool | `false` | `true`, `false` |
+| `firewall_transactional_update_reboot_ok` | raw | `null` | `true`, `false`, or `null` |
+
+```yaml
+- name: Example role usage
+  hosts: all
+  vars:
+    firewall:
+      - service: http
+        state: enabled
+      - port: "8080/tcp"
+        state: enabled
+    firewall_disable_conflicting_services: true
+  roles:
+    - linux-system-roles.firewall
+```
+
 ### firewall_disable_conflicting_services
 
 By default, the firewall role does not attempt to disable conflicting services due to the

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -19,8 +19,10 @@ argument_specs:
       firewall:
         type: raw
         description: >
-          A list of firewall configuration dictionaries, or a single
-          dictionary. Each dictionary describes a desired firewall state
+          A list of firewall configuration dictionaries, a single
+          dictionary, or `null`. When set to `null` or an empty list,
+          the role gathers firewall facts without making changes. Each
+          dictionary describes a desired firewall state
           using one or more of the following keys:
           `service` - list of firewalld service name strings to add or
           remove from a zone. Service names must be defined in the

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -91,6 +91,10 @@ argument_specs:
           existing settings. Defaults to `kept`;
           `includes` - list of service names to include in a custom
           service definition;
+          `detailed` - boolean to request detailed firewall facts. When
+          set to `true` with no other keys, the role gathers and returns
+          extended firewall configuration information in the
+          `firewall_config` fact;
           `firewalld_conf` - dictionary of firewalld.conf directives.
           Currently supports `allow_zone_drifting` (boolean) to set the
           AllowZoneDrifting directive.

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -19,12 +19,12 @@ argument_specs:
     options:
       firewall:
         type: raw
+        default: []
         description: >
           A list of firewall configuration dictionaries, a single
           dictionary, or `null`.
           When set to `null` or an empty list, the role gathers firewall
           facts without making changes.
-          Defaults to an empty list.
           Each dictionary describes a desired firewall state
           using one or more of the following keys:
           `service` - list of firewalld service name strings to add or
@@ -105,14 +105,15 @@ argument_specs:
           AllowZoneDrifting directive.
       firewall_disable_conflicting_services:
         type: bool
+        default: false
         description: >
           Whether to disable and mask services that conflict with firewalld
-          such as iptables, nftables, and ufw. Defaults to `false`.
+          such as iptables, nftables, and ufw.
       firewall_transactional_update_reboot_ok:
         type: raw
+        default: null
         description: >
           Whether to permit reboots required by transactional updates. Set
           to `true` to allow reboots, `false` to disallow reboots, or
           leave unset so that the role will fail to ensure the reboot
           requirement is not overlooked. Accepts a boolean value or `null`.
-          Defaults to `null`.

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+---
+# https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#specification-format
+argument_specs:
+  main:
+    short_description: The firewall role.
+    description: >
+      The firewall role allows you to manage the firewall configuration
+      using firewalld on Fedora and Red Hat Enterprise Linux 7 and later.
+      It can configure zones, services, ports, port forwarding,
+      masquerading, rich rules, ICMP blocks, sources, interfaces, IPSets,
+      and other firewalld settings.
+
+      This role will install and enable the firewalld service, optionally
+      disable conflicting services such as iptables, nftables, and ufw,
+      and apply the desired firewall configuration as specified in the
+      `firewall` variable.
+    options:
+      firewall:
+        type: raw
+        description: >
+          A list of firewall configuration dictionaries, or a single
+          dictionary. Each dictionary describes a desired firewall state
+          using one or more of the following keys:
+          `service` - list of firewalld service name strings to add or
+          remove from a zone. Service names must be defined in the
+          firewalld configuration. A service can be created by setting
+          this to a single service name with `state` set to `present`;
+          `port` - list of port or port range strings in
+          `<port>[-<port>]/<protocol>` format;
+          `source_port` - list of source port or port range strings in
+          `<port>[-<port>]/<protocol>` format;
+          `forward_port` - list of forward port strings or dicts, or a
+          single string or dict, in
+          `<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]` format
+          (alias `port_forward`);
+          `masquerade` - boolean to enable or disable IP masquerading in
+          the zone;
+          `rich_rule` - list of rich language rule strings as described in
+          firewalld.richlanguage(5);
+          `source` - list of source address or address range strings, or
+          IPSet references prefixed with `ipset:`. A source address is an
+          IP address or a network address with a mask for IPv4 or IPv6;
+          `interface` - list of network interface name strings to bind to
+          a zone;
+          `interface_pci_id` - list of PCI device ID strings that
+          correspond to named network interfaces;
+          `icmp_block` - list of ICMP type name strings to block. The ICMP
+          type names must be defined in the firewalld configuration;
+          `icmp_block_inversion` - boolean to enable or disable ICMP block
+          inversion for the zone;
+          `timeout` - integer number of seconds a runtime setting remains
+          in effect, usable for services, ports, source ports, forward
+          ports, masquerade, rich rules, or ICMP blocks;
+          `target` - the firewalld zone target, one of `default`, `ACCEPT`,
+          `DROP`, or `%%REJECT%%`. Setting `state` to `absent` resets the
+          target to `default`;
+          `zone` - the zone name to operate on. If not specified, the
+          default zone is used;
+          `set_default_zone` - sets the default firewalld zone to the given
+          zone name;
+          `ipset` - name of the IPSet to create, modify, or remove.
+          Requires `state` set to `present` or `absent` and `permanent`
+          set to `true`;
+          `ipset_type` - type of the IPSet being created. Required when
+          creating a new IPSet. Use `firewall-cmd --get-ipset-types` to
+          list supported types;
+          `ipset_entries` - list of addresses to add to or remove from the
+          IPSet. Entries must be compatible with the IPSet type;
+          `ipset_options` - dictionary of key/value pairs of IPSet options;
+          `permanent` - boolean to persist settings across system reboots
+          and firewalld service restarts. If not set, runtime is assumed;
+          `runtime` - boolean to apply settings to the runtime environment
+          only, not persistent across reboots (alias `immediate`);
+          `state` - one of `enabled`, `disabled`, `present`, or `absent`.
+          Use `present` and `absent` for zone, service, or target
+          operations;
+          `description` - description string for a custom service or
+          IPSet. Requires `state` set to `present`;
+          `short` - short description string, generally a full name, for a
+          custom service or IPSet. Requires `state` set to `present`;
+          `protocol` - list of protocol strings for service configuration
+          only;
+          `helper_module` - list of netfilter kernel helper module names
+          for service configuration;
+          `destination` - list of IPv4 or IPv6 addresses with optional
+          mask in `address[/mask]` format for service configuration. Only
+          one IPv4 and one IPv6 address are allowed;
+          `previous` - set to `replaced` to replace the entire firewall
+          configuration with the new configuration, or `kept` to preserve
+          existing settings. Defaults to `kept`;
+          `includes` - list of service names to include in a custom
+          service definition;
+          `firewalld_conf` - dictionary of firewalld.conf directives.
+          Currently supports `allow_zone_drifting` (boolean) to set the
+          AllowZoneDrifting directive.
+          Defaults to an empty list.
+      firewall_disable_conflicting_services:
+        type: bool
+        description: >
+          Whether to disable and mask services that conflict with firewalld
+          such as iptables, nftables, and ufw. Defaults to `false`.
+      firewall_transactional_update_reboot_ok:
+        type: raw
+        description: >
+          Whether to permit reboots required by transactional updates. Set
+          to `true` to allow reboots, `false` to disallow reboots, or
+          leave unset so that the role will fail to ensure the reboot
+          requirement is not overlooked. Accepts a boolean value or `null`.
+          Defaults to `null`.

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -7,6 +7,7 @@ argument_specs:
     description: >
       The firewall role allows you to manage the firewall configuration
       using firewalld on Fedora and Red Hat Enterprise Linux 7 and later.
+
       It can configure zones, services, ports, port forwarding,
       masquerading, rich rules, ICMP blocks, sources, interfaces, IPSets,
       and other firewalld settings.
@@ -20,9 +21,11 @@ argument_specs:
         type: raw
         description: >
           A list of firewall configuration dictionaries, a single
-          dictionary, or `null`. When set to `null` or an empty list,
-          the role gathers firewall facts without making changes. Each
-          dictionary describes a desired firewall state
+          dictionary, or `null`.
+          When set to `null` or an empty list, the role gathers firewall
+          facts without making changes.
+          Defaults to an empty list.
+          Each dictionary describes a desired firewall state
           using one or more of the following keys:
           `service` - list of firewalld service name strings to add or
           remove from a zone. Service names must be defined in the
@@ -100,7 +103,6 @@ argument_specs:
           `firewalld_conf` - dictionary of firewalld.conf directives.
           Currently supports `allow_zone_drifting` (boolean) to set the
           AllowZoneDrifting directive.
-          Defaults to an empty list.
       firewall_disable_conflicting_services:
         type: bool
         description: >

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Assert firewall is a list of dicts or a single dict
+  ansible.builtin.assert:
+    that:
+      - >-
+        firewall is mapping
+        or (firewall is sequence and firewall is not string
+            and firewall is not mapping
+            and firewall | reject('mapping') | list | length == 0)
+    fail_msg: >-
+      firewall must be a list of dictionaries or a single dictionary,
+      got {{ firewall | type_debug }}
+  when: firewall is not none
+
+- name: Assert firewall dicts contain only valid keys
+  ansible.builtin.assert:
+    that:
+      - >-
+        item.keys() | list | difference(__firewall_valid_keys)
+        | length == 0
+    fail_msg: >-
+      firewall[{{ idx }}] contains invalid keys:
+      {{ item.keys() | list | difference(__firewall_valid_keys) | join(', ') }}
+  vars:
+    __firewall_valid_keys:
+      - firewalld_conf
+      - service
+      - port
+      - source_port
+      - forward_port
+      - port_forward
+      - masquerade
+      - rich_rule
+      - source
+      - interface
+      - interface_pci_id
+      - icmp_block
+      - icmp_block_inversion
+      - timeout
+      - target
+      - zone
+      - set_default_zone
+      - ipset
+      - ipset_type
+      - ipset_entries
+      - ipset_options
+      - permanent
+      - runtime
+      - immediate
+      - state
+      - description
+      - short
+      - protocol
+      - helper_module
+      - destination
+      - previous
+      - includes
+      - detailed
+  loop: "{{ firewall is mapping | ternary([firewall], firewall) }}"
+  loop_control:
+    index_var: idx
+    label: "{{ idx }}"
+  when:
+    - firewall is not none
+    - firewall | length > 0
+
+- name: Assert firewall_transactional_update_reboot_ok is null or a boolean
+  ansible.builtin.assert:
+    that:
+      - >-
+        (firewall_transactional_update_reboot_ok is none)
+        or (firewall_transactional_update_reboot_ok is sameas true)
+        or (firewall_transactional_update_reboot_ok is sameas false)
+    fail_msg: >-
+      firewall_transactional_update_reboot_ok must be null or a boolean,
+      got {{ firewall_transactional_update_reboot_ok | type_debug }}

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -57,7 +57,11 @@
       - previous
       - includes
       - detailed
-  loop: "{{ firewall is mapping | ternary([firewall], firewall) }}"
+  loop: >-
+    {{ [firewall] if firewall is mapping
+       else (firewall if (firewall is not none and firewall is sequence
+             and firewall is not string and firewall is not mapping)
+       else []) }}
   loop_control:
     index_var: idx
     label: "{{ idx }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Set platform/version specific variables
   include_tasks: set_vars.yml
 
+- name: Validate role parameters
+  ansible.builtin.include_tasks: assert_role_vars.yml
+
 - name: Setup firewalld
   include_tasks: firewalld.yml
 

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: MIT
+---
+# Verify meta/argument_specs.yml and tasks/assert_role_vars.yml reject bad
+# parameters.  Each block runs the role expecting failure; rescue records
+# that outcome.
+- name: Verify invalid parameters are rejected
+  hosts: all
+  tasks:
+    - name: Run invalid input tests
+      block:
+        # --- meta/argument_specs (invalid type) ---
+        # Role argument validation requires Ansible 2.10+; skipped on older
+        # versions.
+
+        - name: Run argument specs validation tests
+          when: ansible_version.full is version('2.10', '>=')
+          block:
+            - name: Argument specs reject invalid firewall_disable_conflicting_services
+              block:
+                - name: Run role with non-boolean firewall_disable_conflicting_services
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+                  vars:
+                    firewall_disable_conflicting_services: not_a_bool
+              rescue:
+                - name: Mark invalid firewall_disable_conflicting_services rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_disable_cs_type_failed: true
+
+            - name: Assert invalid firewall_disable_conflicting_services type failed
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_disable_cs_type_failed | default(false)
+                fail_msg: >-
+                  meta/argument_specs should reject
+                  firewall_disable_conflicting_services values that are not
+                  booleans
+
+        # --- tasks/assert_role_vars.yml (raw type validation) ---
+
+        - name: Assert rejects firewall as a string
+          block:
+            - name: Run role with firewall as a string
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall: not_a_dict_or_list
+          rescue:
+            - name: Mark firewall string rejected
+              ansible.builtin.set_fact:
+                __invalid_input_firewall_string_failed: true
+
+        - name: Assert firewall as string failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_firewall_string_failed | default(false)
+            fail_msg: >-
+              tasks/assert_role_vars.yml should reject firewall when it is
+              a string instead of a list of dicts or a single dict
+
+        - name: Assert rejects firewall as an integer
+          block:
+            - name: Run role with firewall as an integer
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall: 42
+          rescue:
+            - name: Mark firewall integer rejected
+              ansible.builtin.set_fact:
+                __invalid_input_firewall_int_failed: true
+
+        - name: Assert firewall as integer failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_firewall_int_failed | default(false)
+            fail_msg: >-
+              tasks/assert_role_vars.yml should reject firewall when it is
+              an integer instead of a list of dicts or a single dict
+
+        - name: Assert rejects firewall list with non-dict element
+          block:
+            - name: Run role with firewall list containing a string
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall:
+                  - service:
+                      - http
+                    state: enabled
+                  - not_a_dict
+          rescue:
+            - name: Mark firewall list with string element rejected
+              ansible.builtin.set_fact:
+                __invalid_input_firewall_list_str_failed: true
+
+        - name: Assert firewall list with non-dict element failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_firewall_list_str_failed | default(false)
+            fail_msg: >-
+              tasks/assert_role_vars.yml should reject firewall lists
+              containing non-dictionary elements
+
+        - name: Assert rejects firewall dict with invalid key
+          block:
+            - name: Run role with firewall dict containing an unknown key
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall:
+                  - invalid_key_name: some_value
+                    state: enabled
+          rescue:
+            - name: Mark firewall invalid key rejected
+              ansible.builtin.set_fact:
+                __invalid_input_firewall_bad_key_failed: true
+
+        - name: Assert firewall dict with invalid key failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_firewall_bad_key_failed | default(false)
+            fail_msg: >-
+              tasks/assert_role_vars.yml should reject firewall dicts
+              containing keys not in the valid set
+
+        - name: Assert rejects firewall_transactional_update_reboot_ok as string
+          block:
+            - name: Run role with non-boolean transactional_update_reboot_ok
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall_transactional_update_reboot_ok: not_a_bool
+          rescue:
+            - name: Mark invalid transactional_update_reboot_ok rejected
+              ansible.builtin.set_fact:
+                __invalid_input_tu_reboot_type_failed: true
+
+        - name: Assert transactional_update_reboot_ok as string failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_tu_reboot_type_failed | default(false)
+            fail_msg: >-
+              tasks/assert_role_vars.yml should reject
+              firewall_transactional_update_reboot_ok when it is a string
+              instead of null or a boolean
+
+        - name: Assert rejects firewall_transactional_update_reboot_ok as integer
+          block:
+            - name: Run role with integer transactional_update_reboot_ok
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall_transactional_update_reboot_ok: 42
+          rescue:
+            - name: Mark integer transactional_update_reboot_ok rejected
+              ansible.builtin.set_fact:
+                __invalid_input_tu_reboot_int_failed: true
+
+        - name: Assert transactional_update_reboot_ok as integer failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_tu_reboot_int_failed | default(false)
+            fail_msg: >-
+              tasks/assert_role_vars.yml should reject
+              firewall_transactional_update_reboot_ok when it is an integer
+              instead of null or a boolean
+
+        # --- module argument validation (invalid choice / type) ---
+
+        - name: Module rejects invalid state
+          block:
+            - name: Run role with invalid state
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall:
+                  - state: not_a_valid_state
+          rescue:
+            - name: Mark invalid state rejected
+              ansible.builtin.set_fact:
+                __invalid_input_state_failed: true
+
+        - name: Assert invalid state failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_state_failed | default(false)
+            fail_msg: >-
+              The role should reject state values outside the allowed set
+
+        - name: Module rejects invalid target
+          block:
+            - name: Run role with invalid target
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall:
+                  - target: INVALID_TARGET
+                    state: present
+          rescue:
+            - name: Mark invalid target rejected
+              ansible.builtin.set_fact:
+                __invalid_input_target_failed: true
+
+        - name: Assert invalid target failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_target_failed | default(false)
+            fail_msg: >-
+              The role should reject target values outside the allowed set
+
+        - name: Module rejects invalid previous
+          block:
+            - name: Run role with invalid previous
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                firewall:
+                  - previous: not_a_valid_previous
+          rescue:
+            - name: Mark invalid previous rejected
+              ansible.builtin.set_fact:
+                __invalid_input_previous_failed: true
+
+        - name: Assert invalid previous failed validation
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_previous_failed | default(false)
+            fail_msg: >-
+              The role should reject previous values outside the allowed set
+
+      always:
+        - name: Clear test facts
+          ansible.builtin.set_fact:
+            __invalid_input_disable_cs_type_failed:
+            __invalid_input_firewall_string_failed:
+            __invalid_input_firewall_int_failed:
+            __invalid_input_firewall_list_str_failed:
+            __invalid_input_firewall_bad_key_failed:
+            __invalid_input_tu_reboot_type_failed:
+            __invalid_input_tu_reboot_int_failed:
+            __invalid_input_state_failed:
+            __invalid_input_target_failed:
+            __invalid_input_previous_failed:
+          tags: tests::cleanup

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -13,7 +13,7 @@
         # versions.
 
         - name: Run argument specs validation tests
-          when: ansible_version.full is version('2.10', '>=')
+          when: ansible_version.full is version('2.11', '>=')
           block:
             - name: Argument specs reject invalid firewall_disable_conflicting_services
               block:


### PR DESCRIPTION
Enhancement: Added argument spec and assert role spec validation to the Firewall role. Also wrote tests for it found in tests/tests_invalid_input.

Reason: Because it is a good addition to the linux-system-roles project.

Result: Successfully added it and prepared tests for it. I used AI during this implementation.

Issue Tracker Tickets (Jira or BZ if any): https://github.com/linux-system-roles/postfix/issues/206 https://redhat.atlassian.net/browse/RHELMISC-16008


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for firewall role settings, including supported keys, data types, and values.
  * Added clear error messages when invalid configuration is provided.
  * Documented available variables, defaults, accepted values, and example usage.

* **Tests**
  * Added coverage for invalid firewall configurations and module parameters to ensure they are rejected correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->