### PR TITLE
test: use __includes_and_helpers_support in tests_service.yml

### DIFF
--- a/tests/tests_service.yml
+++ b/tests/tests_service.yml
@@ -21,10 +21,7 @@
       destination:
         - 1.1.1.1
         - 1::1
-      includes: "{{ ['ssh', 'ldaps']
-        if ansible_facts['distribution'] in ['RedHat', 'CentOS', 'Fedora']
-        and ansible_facts['distribution_major_version'] is version('8', '>=')
-        else [] }}"
+      includes: "{{ ['ssh', 'ldaps'] if __includes_and_helpers_support else [] }}"
       state: present
     custom_lsr_service:
       service: systemroletest
@@ -40,20 +37,22 @@
         - 1::1
       protocol: icmp
       # these two don't exist yet in RHEL 7
-      helper_module: "{{ 'ftp'
-        if ansible_facts['distribution'] in ['RedHat', 'CentOS', 'Fedora']
-        and ansible_facts['distribution_major_version'] is version('8', '>=')
-        else omit }}"
-      includes: "{{ ['ssh', 'ldaps']
-        if ansible_facts['distribution'] in ['RedHat', 'CentOS', 'Fedora']
-        and ansible_facts['distribution_major_version'] is version('8', '>=')
-        else [] }}"
+      helper_module: "{{ 'ftp' if __includes_and_helpers_support else omit }}"
+      includes: "{{ ['ssh', 'ldaps'] if __includes_and_helpers_support else [] }}"
       state: present
     service_removal:  # to be combine()'d with service definition
       state: absent
       description: "{{ omit }}"
       short: "{{ omit }}"
+  vars_files:
+    - vars/rh_distros_vars.yml
   tasks:
+    # are includes and helpers supported on this distro?
+    - name: Set var for includes and helpers support
+      set_fact:
+        __includes_and_helpers_support: "{{ __firewall_is_rh_distro_fedora
+          and ansible_facts['distribution_major_version'] is version('8', '>=') }}"
+
     - name: Test firewall user defined services
       block:
 


### PR DESCRIPTION
If there is a task such as validate_argument_spec that needs access to `ansible_facts`
to evaluate parameter values, and this runs before the role can gather facts,
the facts will be undefined and you will get an error.  Ensure that this doesn't happen
by using a `set_fact` variable in the parameter values.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for service configuration across supported Fedora-family systems.
  * Unsupported systems now correctly omit unavailable service includes and helper configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->